### PR TITLE
ClientSession can be woken up in order to destruct faster (closes #20)

### DIFF
--- a/src/client_session.hpp
+++ b/src/client_session.hpp
@@ -58,6 +58,7 @@ private:
 
   // Daemon
   thread m_daemon_thread;
+  condition_variable m_monitor;
   mutex m_run_check;
   mutex m_safe_get;
   bool m_is_running;


### PR DESCRIPTION
The way that the ClientSession background thread worked before was that it
unconditionally slept for m_check_interval to throttle the check events. This
works fine during normal execution, but it's a big problem for destruction: the
destructor correctly joins the thread and waits for it to finish, but that means
that the destructor can take up to m_check_interval seconds to execute. This is
not ideal: the destructor runs when the program shuts down, which can mean that
the ClientSession can essentially "lock up" shutdown for a long time without
doing any work.

The fix is to not use unconditional sleep, but to use a std::condition_variable
instead: the condition variable can sleep for a given number of time just like
std::this_thread::sleep_for, but it can also be woken up if needed. This change
wakes the thread up when calling ClientSession::stop(), and the condition
variable reads m_is_running to figure out if it should wake up and exit. This
change makes it so that ClientSession::stop() (and therefore the destructor)
finishes (essentially) instantly, regardless of the value for m_check_interval.