### PR TITLE
Build and release using Github actions (close #27)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: build
+
+on:
+  push:
+
+jobs:
+  test:
+      runs-on: macos-latest
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Make
+        run: make
+
+      - name: Run tests
+        run: make unit-tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - '*.*.*'
+
+jobs:
+  test:
+      runs-on: macos-latest
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Make
+        run: make
+
+      - name: Run tests
+        run: make unit-tests
+
+  release:
+    needs: ["test"]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Get tag version
+      id: version
+      run: echo ::set-output name=TAG_VERSION::${GITHUB_REF#refs/*/}
+
+    - name: Release
+      uses: softprops/action-gh-release@v0.1.7
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        name: Version ${{ steps.version.outputs.TAG_VERSION }}
+        draft: false
+        prerelease: ${{ contains(steps.version.outputs.TAG_VERSION, '-') }}


### PR DESCRIPTION
1. Add Github action to build and run unit tests
2. Add Github action to make a release on Github