### PR TITLE
Allow custom User Agent strings (close #23)

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -29,6 +29,7 @@ int main(int argc, char** argv) {
   subject.set_color_depth(32);
   subject.set_timezone("GMT");
   subject.set_language("EN");
+  subject.set_useragent("Mozilla/5.0");
 
   ClientSession client_session(db_name, 5000, 5000, 2500);
 

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -67,6 +67,7 @@ const string SNOWPLOW_VIEWPORT = "vp";
 const string SNOWPLOW_COLOR_DEPTH = "cd";
 const string SNOWPLOW_TIMEZONE = "tz";
 const string SNOWPLOW_LANGUAGE = "lang";
+const string SNOWPLOW_USERAGENT = "ua";
 
 // structured event
 const string SNOWPLOW_SE_CATEGORY = "se_ca";

--- a/src/subject.cpp
+++ b/src/subject.cpp
@@ -39,6 +39,10 @@ void Subject::set_language(const string & language) {
   this->m_payload.add(SNOWPLOW_LANGUAGE, language);
 }
 
+void Subject::set_useragent(const string & useragent) {
+  this->m_payload.add(SNOWPLOW_USERAGENT, useragent);
+}
+
 map<string, string> Subject::get_map() {
   return this->m_payload.get();
 }

--- a/src/subject.hpp
+++ b/src/subject.hpp
@@ -32,6 +32,7 @@ public:
   void set_color_depth(int depth);
   void set_timezone(const string & timezone);
   void set_language(const string & language);
+  void set_useragent(const string & user_agent);
   map<string, string> get_map();
 };
 

--- a/test/subject_test.cpp
+++ b/test/subject_test.cpp
@@ -47,4 +47,10 @@ TEST_CASE("subject") {
     sub.set_language("EN");
     REQUIRE(sub.get_map()["lang"] == "EN");
   }
+
+  SECTION("set_useragent adds a value for key ua") {
+    string useragent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.78.2 (KHTML, like Gecko) Version/7.0.6 Safari/537.78.2";
+    sub.set_useragent(useragent);
+    REQUIRE(sub.get_map()["ua"] == useragent);
+  }
 }


### PR DESCRIPTION
Adds a `set_useragent()` function to Subject to set a custom useragent by configuring the `ua` property in events.