### PR TITLE
Change all OS-X references to macOS (close #11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ lcov-genhtml: unit-tests
 
 # Dependencies
 
-src/utils_osx.o: src/utils_osx.mm
-	$(OBJCXX) $(CXXFLAGS) src/utils_osx.mm -c -o src/utils_osx.o
+src/utils_macos.o: src/utils_macos.mm
+	$(OBJCXX) $(CXXFLAGS) src/utils_macos.mm -c -o src/utils_macos.o
 
 depend-cxx: .depend-cxx
 .depend-cxx: $(cxx-src-files) $(cxx-test-files) $(cxx-include-files) $(cxx-example-files)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Snowplow event tracker for C++. Add analytics to your C++ applications, servers 
 
 ## Developer Quickstart
 
-### Building on Mac OSX
+### Building on macOS
 
 ```bash
  host> git clone https://github.com/snowplow/snowplow-cpp-tracker

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -186,11 +186,11 @@ HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUr
   return HttpRequestResult(0, http_status_code, row_ids, oversize);
 }
 
-// --- Mac OSX
+// --- macOS
 
 #elif defined(__APPLE__)
 
-const string HttpClient::TRACKER_AGENT = string("Snowplow C++ Tracker (MacOSX)");
+const string HttpClient::TRACKER_AGENT = string("Snowplow C++ Tracker (macOS)");
 
 HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUrl url, const string & query_string, const string & post_data, list<int> row_ids, bool oversize) {
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -39,7 +39,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include <sys/sysctl.h>
 #include <CoreFoundation/CoreFoundation.h>
-#include "utils_osx_interface.h"
+#include "utils_macos_interface.h"
 
 #endif
 

--- a/src/utils_macos.h
+++ b/src/utils_macos.h
@@ -11,13 +11,20 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#ifndef UTILS_OSX_INTERFACE_H
-#define UTILS_OSX_INTERFACE_H
+#ifndef UTILS_MACOS_H
+#define UTILS_MACOS_H
 
-#include <string>
+#if defined(__APPLE__)
 
-using namespace std;
+#import <Foundation/Foundation.h>
+#import <CoreServices/CoreServices.h>
+#import "utils_macos_interface.h"
 
-string get_os_version_objc();
+@interface UtilsMacOS : NSObject
 
++ (NSString *) getOSVersion;
+
+@end
+
+#endif
 #endif

--- a/src/utils_macos.mm
+++ b/src/utils_macos.mm
@@ -11,14 +11,14 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#import "utils_osx.h"
+#import "utils_macos.h"
 
 #if defined(__APPLE__)
 
-@implementation UtilsOSX
+@implementation UtilsMacOS
 
 string get_os_version_objc() {
-    return ([[UtilsOSX getOSVersion] UTF8String]);
+    return ([[UtilsMacOS getOSVersion] UTF8String]);
 }
 
 + (NSString *) getOSVersion {

--- a/src/utils_macos_interface.h
+++ b/src/utils_macos_interface.h
@@ -11,20 +11,13 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#ifndef UTILS_OSX_H
-#define UTILS_OSX_H
+#ifndef UTILS_MACOS_INTERFACE_H
+#define UTILS_MACOS_INTERFACE_H
 
-#if defined(__APPLE__)
+#include <string>
 
-#import <Foundation/Foundation.h>
-#import <CoreServices/CoreServices.h>
-#import "utils_osx_interface.h"
+using namespace std;
 
-@interface UtilsOSX : NSObject
+string get_os_version_objc();
 
-+ (NSString *) getOSVersion;
-
-@end
-
-#endif
 #endif


### PR DESCRIPTION
Replaced instances when OS X was used with the newer macOS name.