### PR TITLE
Add API documentation (close #40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,63 @@
 
 [![early-release]][tracker-classificiation] [![Build Status][travis-image]][travis] [![Coverage Status][coverage-image]][coverage] [![Release][release-image]][releases] [![License][license-image]][license]
 
-## Overview
+Snowplow is a scalable open-source platform for rich, high quality, low-latency data collection. It is designed to collect high quality, complete behavioral data for enterprise business.
 
-Snowplow event tracker for C++. Add analytics to your C++ applications, servers and games
+**To find out more, please check out the [Snowplow website][website] and our [documentation][docs].**
 
-## Developer Quickstart
+## Snowplow C++ Tracker Overview
+
+Snowplow C++ tracker enables you to add analytics to your C++ applications, servers and games when using a [Snowplow][snowplow] pipeline.
+
+## Quick Start
+
+The tracker currently supports macOS and Windows.
+
+### Installation
+
+Download the most recent release from the [releases section](https://github.com/snowplow/snowplow-cpp-tracker/releases). Everything in both the `src` and `include` folders will need to be included in your application. It is important to keep the same folder structure as references to the included headers have been done like so: `../include/json.hpp`.
+
+### Using the tracker
+
+Import and initialize the tracker with your Snowplow collector endpoint and tracker configuration:
+
+```cpp
+#include "tracker.hpp"
+
+// Emitter is responsible for sending events to a Snowplow Collector
+Emitter emitter("com.acme.collector", Emitter::Method::POST, Emitter::Protocol::HTTP, 500, 52000, 52000, "sp.db");
+// Subject defines additional information about your application's environment and user
+Subject subject;
+subject.set_user_id("a-user-id");
+// Client session keeps track of user sessions
+ClientSession client_session("sp.db", 5000, 5000);
+
+string platform = "pc"; // platform the tracker is running on
+string app_id = "openage"; // application ID
+string name_space = "sp-pc"; // the name of the tracker instance
+bool base64 = false; // whether to enable base 64 encoding
+bool desktop_context = true; // add a context entity to events with information about the device
+
+Tracker *tracker = Tracker::init(emitter, &subject, &client_session, &platform, &app_id, &name_space, &base64, &desktop_context);
+```
+
+Track custom events (see the documentation for the full list of supported event types):
+
+```cpp
+// structured event
+Tracker::StructuredEvent se("category", "action");
+tracker->track_struct_event(se);
+
+// screen view event
+Tracker::ScreenViewEvent sve;
+string name = "Screen ID - 5asd56";
+sve.name = &name;
+tracker->track_screen_view(sve);
+```
+
+Check the tracked events in a [Snowplow Micro](https://docs.snowplowanalytics.com/docs/understanding-your-pipeline/what-is-snowplow-micro/) or [Snowplow Mini](https://docs.snowplowanalytics.com/docs/understanding-your-pipeline/what-is-snowplow-mini/) instance.
+
+## Developer Quick Start
 
 ### Building on macOS
 
@@ -107,6 +159,10 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+[website]: https://snowplowanalytics.com
+[snowplow]: https://github.com/snowplow/snowplow
+[docs]: https://docs.snowplowanalytics.com/
 
 [travis-image]: https://travis-ci.org/snowplow/snowplow-cpp-tracker.png?branch=master
 [travis]: https://travis-ci.org/snowplow/snowplow-cpp-tracker

--- a/src/cracked_url.hpp
+++ b/src/cracked_url.hpp
@@ -20,6 +20,9 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 using std::string;
 
+/**
+ * @brief Parser for collector URLs. To be used internally within tracker only.
+ */
 class CrackedUrl {
 public:
   CrackedUrl(const string & url);

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -142,8 +142,7 @@ public:
   /**
    * @brief Check if the Emitter is started.
    * 
-   * @return true Emitter is running
-   * @return false Emitter is not running
+   * @return true if Emitter is running
    */
   bool is_running();
 

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -34,31 +34,117 @@ using std::thread;
 using std::condition_variable;
 using std::mutex;
 
+/**
+ * @brief Emitter is responsible for sending events to a Snowplow Collector.
+ * 
+ * Once the emitter receives an event from the Tracker a few things start to happen:
+ * 
+ * 1. The event is added to a local Sqlite3 database (blocking execution)
+ * 2. A long running daemon thread is started which will continue to send events as long as they can be found in the database (asynchronous)
+ * 3. The emitter loop will grab a range of events from the database up until the SendLimit
+ * 4. The emitter will send all of these events as determined by the Request, Protocol and ByteLimits
+ *    - Each request is sent in its thread.
+ * 5. Once sent it will process the results of all the requests sent and will remove all successfully sent events from the database
+ */
 class Emitter {
 public:
+  /**
+   * @brief HTTP method used to send events to Snowplow Collector.
+   */
   enum Method {
     POST,
     GET
   };
+
+  /**
+   * @brief HTTP protocol used to send events to Snowplow Collector.
+   */
   enum Protocol {
     HTTP,
     HTTPS
   };
 
+  /**
+   * @brief Construct a new Emitter object
+   * 
+   * The `db_name` can be any valid path on your host file system (that can be created with the current user).
+   * By default it will create the required files wherever the application is being run from.
+   * 
+   * @param uri The URI to send events to
+   * @param method The request type to use (GET or POST)
+   * @param protocol The protocol to use (http or https)
+   * @param send_limit The maximum amount of events to send at a time
+   * @param byte_limit_post The byte limit when sending a POST request
+   * @param byte_limit_get The byte limit when sending a GET request
+   * @param db_name Defines the path and file name of the database
+   */
   Emitter(const string & uri, Method method, Protocol protocol, int send_limit, 
     int byte_limit_post, int byte_limit_get, const string & db_name);
   ~Emitter();
 
+  /**
+   * @brief Starts a long running daemon thread for sending events. Triggered automatically by the tracker.
+   */
   virtual void start();
+
+  /**
+   * @brief Stops the long running daemon thread for sending events. Triggered automatically by the tracker.
+   */
   virtual void stop();
+
+  /**
+   * @brief Adds an event to the database for sending. Triggered by tracker.
+   * 
+   * @param payload Event payload
+   */
   virtual void add(Payload payload);
+
+  /**
+   * @brief Force send queued events.
+   */
   virtual void flush();
 
+  /**
+   * @brief Get broken down collector URL.
+   * 
+   * @return CrackedUrl 
+   */
   CrackedUrl get_cracked_url() { return m_url; }
+
+  /**
+   * @brief Get the HTTP method.
+   * 
+   * @return Method HTTP method used for sending events to Collector
+  */
   Method get_method() { return m_method; }
+
+  /**
+   * @brief Get the send limit.
+   * 
+   * @return unsigned int The maximum amount of events to send at a time
+   */
   unsigned int get_send_limit() { return m_send_limit; }
+
+  /**
+   * @brief Get the byte limit for GET.
+   * 
+   * @return unsigned int The byte limit when sending a GET request
+   */
   unsigned int get_byte_limit_get() { return m_byte_limit_get; }
+
+  /**
+   * @brief Get the byte limit for POST.
+   * 
+   * @return unsigned int The byte limit when sending a POST request
+   */
   unsigned int get_byte_limit_post() { return m_byte_limit_post; }
+
+  /**
+   * @brief Check if the Emitter is started.
+   * 
+   * @return true Emitter is running
+   * @return false Emitter is not running
+   */
   bool is_running();
 
 private:

--- a/src/http_client.hpp
+++ b/src/http_client.hpp
@@ -51,6 +51,9 @@ using std::string;
 using std::list;
 using std::mutex;
 
+/**
+ * @brief HTTP client for making requests to Snowplow Collector. To be used internally within tracker only.
+ */
 class HttpClient {
 public:
   enum RequestMethod { POST, GET };

--- a/src/http_request_result.hpp
+++ b/src/http_request_result.hpp
@@ -19,6 +19,9 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 using std::list;
 
+/**
+ * @brief Response from HTTP requests to collector. To be used internally within tracker only.
+ */
 class HttpRequestResult {
 private:
   int m_http_response_code;

--- a/src/payload.hpp
+++ b/src/payload.hpp
@@ -68,7 +68,7 @@ public:
   /**
    * @brief Get the payload key-value pairs.
    * 
-   * @return map<string, string> Payload as key-value pairs
+   * @return Payload as key-value pairs
    */
   map<string, string> get();
 };

--- a/src/payload.hpp
+++ b/src/payload.hpp
@@ -23,16 +23,53 @@ using std::string;
 using std::map;
 using json = nlohmann::json;
 
+/**
+ * @brief Snowplow event payload with event properties.
+ */
 class Payload {
 private:
   map<string, string> m_pairs;
 
 public:
   ~Payload();
+
+  /**
+   * @brief Add a property to the payload.
+   * 
+   * @param key Property key
+   * @param value Property value
+   */
   void add(const string & key, const string & value);
+
+  /**
+   * @brief Add a map of properties to the payload.
+   * 
+   * @param pairs Key-value pairs
+   */
   void add_map(map<string, string> pairs);
+
+  /**
+   * @brief Add properties from another payload.
+   * 
+   * @param p Payload to add values from
+   */
   void add_payload(Payload p);
+
+  /**
+   * @brief Add self-describing JSON data to the payload.
+   * 
+   * @param j Self-describing JSON
+   * @param base64Encode Should the data be base64 encoded
+   * @param encoded Key for encoded data
+   * @param not_encoded Key for not-encoded data
+   */
   void add_json(json j, bool base64Encode, const string & encoded, const string & not_encoded);
+
+  /**
+   * @brief Get the payload key-value pairs.
+   * 
+   * @return map<string, string> Payload as key-value pairs
+   */
   map<string, string> get();
 };
 

--- a/src/self_describing_json.hpp
+++ b/src/self_describing_json.hpp
@@ -21,14 +21,39 @@ See the Apache License Version 2.0 for the specific language governing permissio
 using std::string;
 using json = nlohmann::json;
 
+/**
+ * @brief Self-describing JSON object used for defining self-describing events or custom context entities.
+ */
 class SelfDescribingJson {
 private:
   json m_json;
 
 public:
+  /**
+   * @brief Construct a new Self Describing Json object
+   * 
+   * @param schema Iglu schema (e.g., "iglu:com.snowplowanalytics.snowplow/timing/jsonschema/1-0-0")
+   * @param data Data payload with unstructured set of properties
+   */
   SelfDescribingJson(const string & schema, const json & data);
+
+  /**
+   * @brief Destroy the Self Describing Json object
+   */
   ~SelfDescribingJson();
+
+  /**
+   * @brief Return the content of the self-describing JSON.
+   * 
+   * @return json Content as a JSON object
+   */
   json get();
+
+  /**
+   * @brief Return the content of the self-describing JSON as string.
+   * 
+   * @return string Content as a JSON string
+   */
   string to_string();
 };
 

--- a/src/storage.hpp
+++ b/src/storage.hpp
@@ -30,6 +30,10 @@ using std::string;
 using std::list;
 using json = nlohmann::json;
 
+/**
+ * @brief Tracker internal SQLite storage for events and session information. To be used internally within tracker only.
+ * 
+ */
 class Storage {
 private:
   static Storage *m_instance;

--- a/src/subject.hpp
+++ b/src/subject.hpp
@@ -23,7 +23,7 @@ using std::map;
 using std::string;
 
 /**
- * @brief Defines additional information about your application’s environment, current user and so on, to be sent to with each tracked event.
+ * @brief Defines additional information about your application's environment, current user and so on, to be sent to with each tracked event.
  */
 class Subject {
 private:

--- a/src/subject.hpp
+++ b/src/subject.hpp
@@ -22,18 +22,70 @@ See the Apache License Version 2.0 for the specific language governing permissio
 using std::map;
 using std::string;
 
+/**
+ * @brief Defines additional information about your application’s environment, current user and so on, to be sent to with each tracked event.
+ */
 class Subject {
 private:
   Payload m_payload;
 
 public:
+  /**
+   * @brief Set the business user ID string
+   * 
+   * @param user_id Business user ID
+   */
   void set_user_id(const string & user_id);
+
+  /**
+   * @brief Set the device screen resolution
+   * 
+   * @param width Device screen resolution width
+   * @param height Device screen resolution height
+   */
   void set_screen_resolution(int width, int height);
+
+  /**
+   * @brief Set the device viewport dimensions
+   * 
+   * @param width Device viewport width
+   * @param height Device viewport height
+   */
   void set_viewport(int width, int height);
+
+  /**
+   * @brief Set the bit depth of the device’s color palette for displaying images
+   * 
+   * @param depth Device color depth
+   */
   void set_color_depth(int depth);
+
+  /**
+   * @brief Set the user’s timezone.
+   * 
+   * @param timezone User's timezone (e.g., "Europe/London")
+   */
   void set_timezone(const string & timezone);
+
+  /**
+   * @brief Set the user's language
+   * 
+   * @param language User's language (e.g., "en")
+   */
   void set_language(const string & language);
+
+  /**
+   * @brief Set the useragent string for the event
+   * 
+   * @param user_agent Standard formatted useragent string (e.g., "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4)...")
+   */
   void set_useragent(const string & user_agent);
+
+  /**
+   * @brief Get the subject properties as a map of strings
+   * 
+   * @return map<string, string> Subject properties to be added to events
+   */
   map<string, string> get_map();
 };
 

--- a/src/tracker.hpp
+++ b/src/tracker.hpp
@@ -23,71 +23,300 @@ See the Apache License Version 2.0 for the specific language governing permissio
 using std::string;
 using std::vector;
 
+/**
+ * @brief Singleton object that provides an interface to track Snowplow events.
+ */
 class Tracker {
 public:
+  /**
+   * @brief Initializes and returns the singleton tracker instance.
+   * 
+   * @param emitter The emitter to which events are sent (required).
+   * @param subject The user being tracked (optional).
+   * @param client_session Client session object responsible for tracking user sessions (optional). Attach a ClientSession context to each event.
+   * @param platform The platform the Tracker is running on, can be one of: web, mob, pc, app, srv, tv, cnsl, iot (defaults to srv).
+   * @param app_id Application ID (defaults to empty string).
+   * @param name_space The name of the tracker instance attached to every event (defaults to empty string).
+   * @param use_base64 Whether to enable base 64 encoding (defaults to true).
+   * @param desktop_context Whether to add a desktop_context, which gathers information about the device the tracker is running on, to each event (defaults to true).
+   * @return Tracker* 
+   */
   static Tracker *init(Emitter &emitter, Subject *subject, ClientSession *client_session, string *platform, 
     string *app_id, string *name_space, bool *use_base64, bool *desktop_context);
+
+  /**
+   * @brief Returns the initialized singleton tracker instance.
+   * 
+   * @return Tracker* Tracker instance.
+   */
   static Tracker *instance();
+
+  /**
+   * @brief Clean up the tracker to be used in main destructor.
+   */
   static void close();
 
+  /**
+   * @brief  Event to capture custom consumer interactions without the need to define a custom schema.
+   */
   class StructuredEvent {
   public:
+    /**
+     * @brief Name for the group of objects you want to track e.g. "media", "ecomm".
+     */
     string category; // required
+
+    /**
+     * @brief Defines the type of user interaction for the web object.
+     * 
+     * E.g., "play-video", "add-to-basket".
+     */
     string action; // required
+
+    /**
+     * @brief Identifies the specific object being actioned.
+     * 
+     * E.g., ID of the video being played, or the SKU or the product added-to-basket.
+     */
     string *label;
+  
+    /**
+     * @brief Describes the object or the action performed on it.
+     * 
+     * This might be the quantity of an item added to basket
+     */
     string *property;
+
+    /**
+     * @brief Quantifies or further describes the user action.
+     * 
+     * This might be the price of an item added-to-basket, or the starting time of the video where play was just pressed.
+     */
     double *value;
+
+    /**
+     * @brief Unix timestamp (in ms) when the event was created. Assigned automatically.
+     */
     unsigned long long timestamp;
+
+    /**
+     * @brief ID of the event (UUID v4) that is assigned automatically.
+     */
     string event_id;
+
+    /**
+     * @brief Optional, user-defined Unix timestamp (in ms) for the event to override the automatically assigned one.
+     */
     unsigned long long *true_timestamp;
+
+    /**
+     * @brief Context entities added to the event.
+     * 
+     */
     vector<SelfDescribingJson> contexts;
+
+    /**
+     * @brief Construct a new Structured Event object
+     * 
+     * @param category Name for the group of objects you want to track e.g. "media", "ecomm".
+     * @param action Defines the type of user interaction for the web object.
+     */
     StructuredEvent(string category, string action);
   };
 
+  /**
+   * @brief Event to track custom information that does not fit into the out-of-the box events.
+   * 
+   * Self-describing events are a [data structure based on JSON Schemas](https://docs.snowplowanalytics.com/docs/understanding-tracking-design/understanding-schemas-and-validation/)
+   * and can have arbitrarily many fields.
+   * To define your own custom self-describing event, you must create a JSON schema for that
+   * event and upload it to an [Iglu Schema Repository](https://github.com/snowplow/iglu) using
+   * [igluctl](https://docs.snowplowanalytics.com/docs/open-source-components-and-applications/iglu/)
+   * (or if a Snowplow BDP customer, you can use the
+   * [Snowplow BDP Console UI](https://docs.snowplowanalytics.com/docs/understanding-tracking-design/managing-data-structures/)
+   * or [Data Structures API](https://docs.snowplowanalytics.com/docs/understanding-tracking-design/managing-data-structures-via-the-api-2/)).
+   * Snowplow uses the schema to validate that the JSON containing the event properties is well-formed.
+   */
   class SelfDescribingEvent {
   public:
+    /**
+     * @brief Main properties of the self-describing event including it's schema and body
+     */
     SelfDescribingJson event; // required
+
+    /**
+     * @brief Unix timestamp (in ms) when the event was created. Assigned automatically.
+     */
     unsigned long long timestamp;
+
+    /**
+     * @brief ID of the event (UUID v4) that is assigned automatically.
+     */
     string event_id;
+
+    /**
+     * @brief Optional, user-defined Unix timestamp (in ms) for the event to override the automatically assigned one.
+     */
     unsigned long long *true_timestamp;
+
+    /**
+     * @brief Context entities added to the event.
+     */
     vector<SelfDescribingJson> contexts;
+
+    /**
+     * @brief Construct a new Self Describing Event object
+     * 
+     * @param event Main properties of the self-describing event including it's schema and body
+     */
     SelfDescribingEvent(SelfDescribingJson event);
   };
 
+  /**
+   * @brief Event to track user viewing a screen within the application.
+   * 
+   * Schema for the event: iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0
+   */
   class ScreenViewEvent {
   public:
+    /**
+     * @brief The name of the screen viewed.
+     */
     string *name;
+
+    /**
+     * @brief The id of screen that was viewed.
+     */
     string *id;
+
+    /**
+     * @brief Unix timestamp (in ms) when the event was created. Assigned automatically.
+     */
     unsigned long long timestamp;
+
+    /**
+     * @brief ID of the event (UUID v4) that is assigned automatically.
+     */
     string event_id;
+
+    /**
+     * @brief Optional, user-defined Unix timestamp (in ms) for the event to override the automatically assigned one.
+     */
     unsigned long long *true_timestamp;
+
+    /**
+     * @brief Context entities added to the event.
+     */
     vector<SelfDescribingJson> contexts;
+
+    /**
+     * @brief Construct a new Screen View Event object
+     */
     ScreenViewEvent();
   };
 
+  /**
+   * @brief Event used to track user timing events such as how long resources take to load.
+   * 
+   * Schema: iglu:com.snowplowanalytics.snowplow/timing/jsonschema/1-0-0
+   */
   class TimingEvent {
   public:
+    /**
+     * @brief Defines the timing category.
+     */
     string category; // required
+
+    /**
+     * @brief Defines the timing variable measured.
+     */
     string variable; // required
+
+    /**
+     * @brief Represents the time.
+     */
     unsigned long long timing; // required
+
+    /**
+     * @brief An optional string to further identify the timing event.
+     */
     string *label;
+
+    /**
+     * @brief Unix timestamp (in ms) when the event was created. Assigned automatically.
+     */
     unsigned long long timestamp;
+
+    /**
+     * @brief ID of the event (UUID v4) that is assigned automatically.
+     */
     string event_id;
+
+    /**
+     * @brief Optional, user-defined Unix timestamp (in ms) for the event to override the automatically assigned one.
+     */
     unsigned long long *true_timestamp;
+
+    /**
+     * @brief Context entities added to the event.
+     * 
+     */
     vector<SelfDescribingJson> contexts;
+
+    /**
+     * @brief Construct a new Timing Event object
+     * 
+     * @param category Defines the timing category.
+     * @param variable Defines the timing variable measured.
+     * @param timing Represents the time.
+     */
     TimingEvent(string category, string variable, unsigned long long timing);
   };
 
   void start();
   void stop();
+
+  /**
+   * @brief Used to ensure all of your events are sent before closing your application.
+
+   * It is a blocking call that will send everything in the database and then will join the daemon thread to the calling thread.
+   */
   void flush();
 
+  /**
+   * @brief Set the optional subject object after tracker initialization.
+   * 
+   * @param subject Instance of subject
+   */
   void set_subject(Subject *subject);
 
+  /**
+   * @brief Track en event with custom payload. We do not recommend using this function. Instead, track events using the predefined functions for each event.
+   * 
+   * @param p Event payload
+   * @param event_id ID of the event
+   * @param contexts Vector of custom contexts
+   */
   void track(Payload p, const string & event_id, vector<SelfDescribingJson> &contexts);
+
+  /**
+   * @brief Track a Snowplow custom structured event which fits the Google Analytics-style structure of having up to five fields.
+   */
   void track_struct_event(StructuredEvent);
+
+  /**
+   * @brief Track the user viewing a screen within the application.
+   */
   void track_screen_view(ScreenViewEvent);
+
+  /**
+   * @brief Track a timing event.
+   */
   void track_timing(TimingEvent);
+
+  /**
+   * @brief Track a Snowplow custom unstructured event.
+   */
   void track_self_describing_event(SelfDescribingEvent);
 
 private:

--- a/src/tracker.hpp
+++ b/src/tracker.hpp
@@ -96,11 +96,13 @@ public:
 
     /**
      * @brief Unix timestamp (in ms) when the event was created. Assigned automatically.
+     * @deprecated Use the `true_timestamp` instead.
      */
     unsigned long long timestamp;
 
     /**
      * @brief ID of the event (UUID v4) that is assigned automatically.
+     * @deprecated The ability to set custom event ID will be removed in the future
      */
     string event_id;
 
@@ -146,11 +148,13 @@ public:
 
     /**
      * @brief Unix timestamp (in ms) when the event was created. Assigned automatically.
+     * @deprecated Use the `true_timestamp` instead.
      */
     unsigned long long timestamp;
 
     /**
      * @brief ID of the event (UUID v4) that is assigned automatically.
+     * @deprecated The ability to set custom event ID will be removed in the future
      */
     string event_id;
 
@@ -191,11 +195,13 @@ public:
 
     /**
      * @brief Unix timestamp (in ms) when the event was created. Assigned automatically.
+     * @deprecated Use the `true_timestamp` instead.
      */
     unsigned long long timestamp;
 
     /**
      * @brief ID of the event (UUID v4) that is assigned automatically.
+     * @deprecated The ability to set custom event ID will be removed in the future
      */
     string event_id;
 
@@ -244,11 +250,13 @@ public:
 
     /**
      * @brief Unix timestamp (in ms) when the event was created. Assigned automatically.
+     * @deprecated Use the `true_timestamp` instead.
      */
     unsigned long long timestamp;
 
     /**
      * @brief ID of the event (UUID v4) that is assigned automatically.
+     * @deprecated The ability to set custom event ID will be removed in the future
      */
     string event_id;
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -47,6 +47,9 @@ using std::list;
 using std::string;
 using json = nlohmann::json;
 
+/**
+ * @brief Tracker internal utility functions.
+ */
 class Utils {
 public:
   static string get_uuid4();


### PR DESCRIPTION
* Adds comments to all public interface classes, functions, and properties (except `ClientSession` which is changed and commented in another PR)
* Adds a quick start to README

I was considering adding auto-generating of API docs to be hosted on Github Pages but decided to hold off on that idea. I think the comments already provide value as they are recognized by most IDEs and there are no good tools to auto-generate documentation for C++. The best one that I could find is [Sphinx](https://www.sphinx-doc.org/en/master/) which is a tool for Python but can be adapted with another package to generate docs from Doxygen. However, it introduces a lot of overhead and configuration and I'm not sure if it's worth it.