### PR TITLE
Use snowplow namespace (close #13)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+ColumnLimit: 0
+---

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Import and initialize the tracker with your Snowplow collector endpoint and trac
 ```cpp
 #include "tracker.hpp"
 
+using namespace snowplow;
+
 // Emitter is responsible for sending events to a Snowplow Collector
 Emitter emitter("com.acme.collector", Emitter::Method::POST, Emitter::Protocol::HTTP, 500, 52000, 52000, "sp.db");
 // Subject defines additional information about your application's environment and user

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -8,15 +8,15 @@ using snowplow::ClientSession;
 using snowplow::Emitter;
 using snowplow::Subject;
 using snowplow::Tracker;
-using std::string;
 using std::cout;
 using std::endl;
+using std::string;
 
 void usage(char *program_name) {
   cout << "Usage: " << program_name << " [COLLECTOR_URI]" << endl;
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   if (argc != 2) {
     usage(argv[0]);
     return 1;
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
   Tracker *t = Tracker::init(emitter, &subject, &client_session, &platform, &app_id, &name_space, &base64, &desktop_context);
 
   time_t start, end;
-  time (&start);
+  time(&start);
 
   for (int i = 0; i < 2000; i++) {
     Tracker::TimingEvent te("timing-cat", "timing-var", 123);
@@ -69,17 +69,17 @@ int main(int argc, char** argv) {
     t->track_struct_event(se);
   }
 
-  time (&end);
-  double diff = difftime (end,start);
+  time(&end);
+  double diff = difftime(end, start);
   printf("It took me %f seconds to build and store 6000 events.\n", diff);
 
   // Flush and close
   t->flush();
   Tracker::close();
 
-  time (&end);
-  diff = difftime (end,start);
+  time(&end);
+  diff = difftime(end, start);
   printf("It took me %f seconds to send 6000 events.\n", diff);
-  
+
   return 0;
 }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -4,6 +4,10 @@
 
 #include "../src/tracker.hpp"
 
+using snowplow::ClientSession;
+using snowplow::Emitter;
+using snowplow::Subject;
+using snowplow::Tracker;
 using std::string;
 using std::cout;
 using std::endl;

--- a/performance/main.cpp
+++ b/performance/main.cpp
@@ -14,17 +14,17 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include <fstream>
 #include <string>
 
-#include "run.hpp"
-#include "../src/utils.hpp"
 #include "../src/storage.hpp"
+#include "../src/utils.hpp"
+#include "run.hpp"
 
 using snowplow::SelfDescribingJson;
 using snowplow::SNOWPLOW_TRACKER_VERSION_LABEL;
 using snowplow::Utils;
-using std::string;
-using std::endl;
 using std::cout;
+using std::endl;
 using std::ofstream;
+using std::string;
 
 int main(int argc, char **argv) {
   // run and measure performance
@@ -35,7 +35,9 @@ int main(int argc, char **argv) {
   double mute_emitter_and_real_session = run_mute_emitter_and_real_session(db_name);
 
   // print results
-  cout << endl << "RESULTS (" << NUM_OPERATIONS << " operations x " << NUM_THREADS << " threads)" << endl << endl;
+  cout << endl
+       << "RESULTS (" << NUM_OPERATIONS << " operations x " << NUM_THREADS << " threads)" << endl
+       << endl;
   cout << "Mocked emitter and mocked session: " << mocked_emitter_and_mocked_session << " seconds" << endl;
   cout << "Mocked emitter and real session: " << mocked_emitter_and_real_session << " seconds" << endl;
   cout << "Mute emitter and mocked session: " << mute_emitter_and_mocked_session << " seconds" << endl;
@@ -60,7 +62,7 @@ int main(int argc, char **argv) {
 
   ofstream outfile;
   outfile.open("performance/logs.txt", std::ios_base::app);
-  outfile << output.dump() << endl; 
+  outfile << output.dump() << endl;
   outfile.close();
 
   return 0;

--- a/performance/main.cpp
+++ b/performance/main.cpp
@@ -18,6 +18,9 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../src/utils.hpp"
 #include "../src/storage.hpp"
 
+using snowplow::SelfDescribingJson;
+using snowplow::SNOWPLOW_TRACKER_VERSION_LABEL;
+using snowplow::Utils;
 using std::string;
 using std::endl;
 using std::cout;

--- a/performance/mock_client_session.hpp
+++ b/performance/mock_client_session.hpp
@@ -16,6 +16,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "../src/client_session.hpp"
 
+using snowplow::ClientSession;
+using snowplow::SelfDescribingJson;
 using std::string;
 
 class MockClientSession : public ClientSession {

--- a/performance/mock_emitter.hpp
+++ b/performance/mock_emitter.hpp
@@ -16,6 +16,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "../src/emitter.hpp"
 
+using snowplow::Emitter;
+using snowplow::Payload;
 using std::string;
 
 class MockEmitter : public Emitter {

--- a/performance/mute_emitter.hpp
+++ b/performance/mute_emitter.hpp
@@ -16,6 +16,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "../src/emitter.hpp"
 
+using snowplow::Emitter;
 using std::string;
 
 class MuteEmitter : public Emitter {

--- a/performance/run.cpp
+++ b/performance/run.cpp
@@ -22,6 +22,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "mute_emitter.hpp"
 #include "mock_client_session.hpp"
 
+using snowplow::ClientSession;
+using snowplow::Emitter;
+using snowplow::Storage;
+using snowplow::Subject;
+using snowplow::Tracker;
 using std::chrono::high_resolution_clock;
 using std::chrono::duration;
 using std::vector;

--- a/performance/run.cpp
+++ b/performance/run.cpp
@@ -11,25 +11,24 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include <string>
 #include <chrono>
+#include <string>
 
-#include "run.hpp"
-#include "../src/tracker.hpp"
 #include "../src/subject.hpp"
+#include "../src/tracker.hpp"
+#include "mock_client_session.hpp"
 #include "mock_emitter.hpp"
-#include "mock_client_session.hpp"
 #include "mute_emitter.hpp"
-#include "mock_client_session.hpp"
+#include "run.hpp"
 
 using snowplow::ClientSession;
 using snowplow::Emitter;
 using snowplow::Storage;
 using snowplow::Subject;
 using snowplow::Tracker;
-using std::chrono::high_resolution_clock;
-using std::chrono::duration;
 using std::vector;
+using std::chrono::duration;
+using std::chrono::high_resolution_clock;
 
 void clear_storage(const string &db_name);
 

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -12,15 +12,15 @@ See the Apache License Version 2.0 for the specific language governing permissio
 */
 
 #include "client_session.hpp"
-#include "utils.hpp"
 #include "constants.hpp"
 #include "storage.hpp"
+#include "utils.hpp"
 
 using namespace snowplow;
 using std::lock_guard;
 using std::unique_lock;
 
-ClientSession::ClientSession(const string & db_name, unsigned long long foreground_timeout, unsigned long long background_timeout) {
+ClientSession::ClientSession(const string &db_name, unsigned long long foreground_timeout, unsigned long long background_timeout) {
   Storage::init(db_name);
   this->m_foreground_timeout = foreground_timeout;
   this->m_background_timeout = background_timeout;
@@ -30,7 +30,7 @@ ClientSession::ClientSession(const string & db_name, unsigned long long foregrou
   this->m_is_new_session = true;
 
   // Check for existing session
-  list<json>* session_rows = new list<json>;
+  list<json> *session_rows = new list<json>;
   Storage::instance()->select_all_session_rows(session_rows);
 
   if (session_rows->size() == 1) {
@@ -39,7 +39,7 @@ ClientSession::ClientSession(const string & db_name, unsigned long long foregrou
 
       this->m_user_id = session_context[SNOWPLOW_SESSION_USER_ID].get<std::string>();
       this->m_current_session_id = session_context[SNOWPLOW_SESSION_ID].get<std::string>();
-      this->m_session_index = session_context[SNOWPLOW_SESSION_INDEX].get<unsigned long long>();  
+      this->m_session_index = session_context[SNOWPLOW_SESSION_INDEX].get<unsigned long long>();
     } catch (...) {
       this->m_user_id = Utils::get_uuid4();
       this->m_current_session_id = "";
@@ -54,7 +54,7 @@ ClientSession::ClientSession(const string & db_name, unsigned long long foregrou
   this->update_last_session_check_at();
 
   session_rows->clear();
-  delete(session_rows);
+  delete (session_rows);
 }
 
 // --- Public
@@ -63,7 +63,7 @@ void ClientSession::start_new_session() {
   this->m_is_new_session = true;
 }
 
-SelfDescribingJson ClientSession::update_and_get_session_context(const string & event_id) {
+SelfDescribingJson ClientSession::update_and_get_session_context(const string &event_id) {
   json session_context_data;
   bool save_to_storage = false;
 
@@ -130,7 +130,7 @@ void ClientSession::update_session(const string &event_id) {
   j[SNOWPLOW_SESSION_ID] = this->m_current_session_id;
   j[SNOWPLOW_SESSION_INDEX] = this->m_session_index;
   j[SNOWPLOW_SESSION_STORAGE] = this->m_session_storage;
-  
+
   if (this->m_previous_session_id == "") {
     j[SNOWPLOW_SESSION_PREVIOUS_ID] = nullptr;
   } else {

--- a/src/client_session.cpp
+++ b/src/client_session.cpp
@@ -16,6 +16,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "constants.hpp"
 #include "storage.hpp"
 
+using namespace snowplow;
 using std::lock_guard;
 using std::unique_lock;
 

--- a/src/client_session.hpp
+++ b/src/client_session.hpp
@@ -23,6 +23,7 @@ using std::string;
 using std::mutex;
 using json = nlohmann::json;
 
+namespace snowplow {
 /**
  * @brief Keeps track of users sessions and can be configured to timeout after a certain amount of inactivity.
  * 
@@ -107,5 +108,6 @@ private:
   bool should_update_session();
   unsigned long long get_timeout();
 };
+}
 
 #endif

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -18,6 +18,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 using std::string;
 
+namespace snowplow {
 const string SNOWPLOW_TRACKER_VERSION_LABEL = "cpp-0.1.0";
 
 // post requests
@@ -107,5 +108,6 @@ const string SNOWPLOW_DESKTOP_OS_IS_64_BIT = "osIs64Bit";
 const string SNOWPLOW_DESKTOP_DEVICE_MANU = "deviceManufacturer";
 const string SNOWPLOW_DESKTOP_DEVICE_MODEL = "deviceModel";
 const string SNOWPLOW_DESKTOP_DEVICE_PROC_COUNT = "deviceProcessorCount";
+}
 
 #endif

--- a/src/cracked_url.cpp
+++ b/src/cracked_url.cpp
@@ -13,6 +13,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "cracked_url.hpp"
 
+using namespace snowplow;
 using std::regex;
 using std::regex_match;
 using std::smatch;

--- a/src/cracked_url.cpp
+++ b/src/cracked_url.cpp
@@ -19,7 +19,7 @@ using std::regex_match;
 using std::smatch;
 using std::stringstream;
 
-CrackedUrl::CrackedUrl(const string & url) {
+CrackedUrl::CrackedUrl(const string &url) {
   string cleaned_url = url;
   if (regex_match(cleaned_url, regex("^https?://.+")) == false) {
     cleaned_url = string("http://") + url;

--- a/src/cracked_url.hpp
+++ b/src/cracked_url.hpp
@@ -20,6 +20,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 using std::string;
 
+namespace snowplow {
 /**
  * @brief Parser for collector URLs. To be used internally within tracker only.
  */
@@ -44,5 +45,6 @@ private:
   unsigned int port;
   bool use_default_port;
 };
+}
 
 #endif

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -13,6 +13,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "emitter.hpp"
 
+using namespace snowplow;
 using std::lock_guard;
 using std::stringstream;
 using std::invalid_argument;

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -34,6 +34,7 @@ using std::thread;
 using std::condition_variable;
 using std::mutex;
 
+namespace snowplow {
 /**
  * @brief Emitter is responsible for sending events to a Snowplow Collector.
  * 
@@ -166,5 +167,6 @@ private:
   string build_post_data_json(list<Payload> payload_list);
   string get_collector_url(const string & uri, Protocol protocol, Method method);
 };
+}
 
 #endif

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -13,6 +13,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "http_client.hpp"
 
+using namespace snowplow;
 using std::lock_guard;
 using std::cerr;
 using std::endl;

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -14,18 +14,18 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "http_client.hpp"
 
 using namespace snowplow;
-using std::lock_guard;
 using std::cerr;
 using std::endl;
+using std::lock_guard;
 
 // --- Common
 
-HttpRequestResult HttpClient::http_post(const CrackedUrl url, const string & post_data, list<int> row_ids, bool oversize) {
+HttpRequestResult HttpClient::http_post(const CrackedUrl url, const string &post_data, list<int> row_ids, bool oversize) {
   HttpRequestResult res = HttpClient::http_request(POST, url, "", post_data, row_ids, oversize);
   return res;
 }
 
-HttpRequestResult HttpClient::http_get(const CrackedUrl url, const string & query_string, list<int> row_ids, bool oversize) {
+HttpRequestResult HttpClient::http_get(const CrackedUrl url, const string &query_string, list<int> row_ids, bool oversize) {
   HttpRequestResult res = HttpClient::http_request(GET, url, query_string, "", row_ids, oversize);
   return res;
 }
@@ -40,9 +40,9 @@ list<HttpClient::Request> HttpClient::requests_list;
 mutex HttpClient::log_read_write;
 int HttpClient::response_code = 200;
 
-HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUrl url, const string & query_string, const string & post_data, list<int> row_ids, bool oversize) {
+HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUrl url, const string &query_string, const string &post_data, list<int> row_ids, bool oversize) {
   lock_guard<mutex> guard(log_read_write);
-  
+
   HttpClient::Request r;
   r.method = method;
   r.query_string = query_string;
@@ -76,15 +76,14 @@ void HttpClient::reset() {
 
 const string HttpClient::TRACKER_AGENT = string("Snowplow C++ Tracker (Win32)");
 
-HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUrl url, const string & query_string, const string & post_data, list<int> row_ids, bool oversize) {
+HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUrl url, const string &query_string, const string &post_data, list<int> row_ids, bool oversize) {
 
   HINTERNET h_internet = InternetOpen(
-    TEXT(HttpClient::TRACKER_AGENT.c_str()),
-    INTERNET_OPEN_TYPE_DIRECT,
-    NULL,
-    NULL,
-    0
-  );
+      TEXT(HttpClient::TRACKER_AGENT.c_str()),
+      INTERNET_OPEN_TYPE_DIRECT,
+      NULL,
+      NULL,
+      0);
 
   if (h_internet == NULL) {
     return HttpRequestResult(GetLastError(), 0, row_ids, oversize);
@@ -100,15 +99,14 @@ HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUr
   }
 
   HINTERNET h_connect = InternetConnect(
-    h_internet,
-    TEXT(url.get_hostname().c_str()),
-    use_port,
-    NULL,
-    NULL,
-    INTERNET_SERVICE_HTTP,
-    0,
-    NULL
-  );
+      h_internet,
+      TEXT(url.get_hostname().c_str()),
+      use_port,
+      NULL,
+      NULL,
+      INTERNET_SERVICE_HTTP,
+      0,
+      NULL);
 
   if (h_connect == NULL) {
     InternetCloseHandle(h_internet);
@@ -136,15 +134,14 @@ HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUr
   }
 
   HINTERNET h_request = HttpOpenRequest(
-    h_connect,
-    TEXT(request_method_string.c_str()),
-    TEXT(final_path.c_str()),
-    NULL,
-    NULL,
-    NULL,
-    flags,
-    0
-  );
+      h_connect,
+      TEXT(request_method_string.c_str()),
+      TEXT(final_path.c_str()),
+      NULL,
+      NULL,
+      NULL,
+      flags,
+      0);
 
   if (h_request == NULL) {
     InternetCloseHandle(h_internet);
@@ -152,7 +149,7 @@ HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUr
     return HttpRequestResult(GetLastError(), 0, row_ids, oversize);
   }
 
-  LPCSTR hdrs = TEXT("Content-Type: application/json; charset=utf-8");  
+  LPCSTR hdrs = TEXT("Content-Type: application/json; charset=utf-8");
   BOOL is_sent = HttpSendRequest(h_request, hdrs, strlen(hdrs), post_buf, post_buf_len);
 
   if (!is_sent) {
@@ -177,12 +174,11 @@ HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUr
   DWORD http_status_code = 0;
   DWORD length = sizeof(DWORD);
   HttpQueryInfo(
-    h_request,
-    HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER,
-    &http_status_code,
-    &length,
-    NULL
-  );
+      h_request,
+      HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER,
+      &http_status_code,
+      &length,
+      NULL);
 
   InternetCloseHandle(h_request);
   InternetCloseHandle(h_connect);
@@ -197,7 +193,7 @@ HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUr
 
 const string HttpClient::TRACKER_AGENT = string("Snowplow C++ Tracker (macOS)");
 
-HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUrl url, const string & query_string, const string & post_data, list<int> row_ids, bool oversize) {
+HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUrl url, const string &query_string, const string &post_data, list<int> row_ids, bool oversize) {
 
   // Get final url
   string final_url = url.to_string();
@@ -206,9 +202,9 @@ HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUr
   }
 
   // Create request
-  CFStringRef cf_url_str = CFStringCreateWithBytes(kCFAllocatorDefault, (const unsigned char *) final_url.c_str(), final_url.length(), kCFStringEncodingUTF8, false);
-  CFStringRef cf_content_type_str = CFStringCreateWithBytes(kCFAllocatorDefault, (const unsigned char *) SNOWPLOW_POST_CONTENT_TYPE.c_str(), SNOWPLOW_POST_CONTENT_TYPE.length(), kCFStringEncodingUTF8, false);
-  CFStringRef cf_user_agent_str = CFStringCreateWithBytes(kCFAllocatorDefault, (const unsigned char *) HttpClient::TRACKER_AGENT.c_str(), HttpClient::TRACKER_AGENT.length(), kCFStringEncodingUTF8, false);
+  CFStringRef cf_url_str = CFStringCreateWithBytes(kCFAllocatorDefault, (const unsigned char *)final_url.c_str(), final_url.length(), kCFStringEncodingUTF8, false);
+  CFStringRef cf_content_type_str = CFStringCreateWithBytes(kCFAllocatorDefault, (const unsigned char *)SNOWPLOW_POST_CONTENT_TYPE.c_str(), SNOWPLOW_POST_CONTENT_TYPE.length(), kCFStringEncodingUTF8, false);
+  CFStringRef cf_user_agent_str = CFStringCreateWithBytes(kCFAllocatorDefault, (const unsigned char *)HttpClient::TRACKER_AGENT.c_str(), HttpClient::TRACKER_AGENT.length(), kCFStringEncodingUTF8, false);
 
   CFURLRef cf_url = CFURLCreateWithString(kCFAllocatorDefault, cf_url_str, NULL);
   CFHTTPMessageRef cf_http_req;
@@ -217,7 +213,7 @@ HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUr
     cf_http_req = CFHTTPMessageCreateRequest(kCFAllocatorDefault, CFSTR("GET"), cf_url, kCFHTTPVersion1_1);
   } else {
     cf_http_req = CFHTTPMessageCreateRequest(kCFAllocatorDefault, CFSTR("POST"), cf_url, kCFHTTPVersion1_1);
-    CFDataRef cf_post_data = CFDataCreate(kCFAllocatorDefault, (const UInt8*) post_data.data(), post_data.size());
+    CFDataRef cf_post_data = CFDataCreate(kCFAllocatorDefault, (const UInt8 *)post_data.data(), post_data.size());
     CFHTTPMessageSetBody(cf_http_req, cf_post_data);
     if (cf_post_data) {
       CFRelease(cf_post_data);
@@ -237,7 +233,7 @@ HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUr
     const int buff_size = 1024;
     UInt8 buff[buff_size];
     num_bytes_read = CFReadStreamRead(cf_read_stream, buff, buff_size);
- 
+
     if (num_bytes_read > 0) {
       CFDataAppendBytes(cf_data_resp, buff, num_bytes_read);
     } else if (num_bytes_read < 0) {
@@ -247,9 +243,9 @@ HttpRequestResult HttpClient::http_request(const RequestMethod method, CrackedUr
   } while (num_bytes_read > 0);
 
   // Process result
-  CFHTTPMessageRef cf_http_resp = (CFHTTPMessageRef) CFReadStreamCopyProperty(cf_read_stream, kCFStreamPropertyHTTPResponseHeader);
+  CFHTTPMessageRef cf_http_resp = (CFHTTPMessageRef)CFReadStreamCopyProperty(cf_read_stream, kCFStreamPropertyHTTPResponseHeader);
   int cf_status_code = CFHTTPMessageGetResponseStatusCode(cf_http_resp);
-  
+
   // Release resources
   CFReadStreamClose(cf_read_stream);
   CFRelease(cf_url_str);

--- a/src/http_client.hpp
+++ b/src/http_client.hpp
@@ -51,6 +51,7 @@ using std::string;
 using std::list;
 using std::mutex;
 
+namespace snowplow {
 /**
  * @brief HTTP client for making requests to Snowplow Collector. To be used internally within tracker only.
  */
@@ -84,5 +85,6 @@ public:
 private:
   static HttpRequestResult http_request(const RequestMethod method, const CrackedUrl url, const string & query_string, const string & post_data, list<int> row_ids, bool oversize);
 };
+}
 
 #endif

--- a/src/http_request_result.cpp
+++ b/src/http_request_result.cpp
@@ -13,6 +13,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "http_request_result.hpp"
 
+using namespace snowplow;
+
 HttpRequestResult::HttpRequestResult() {
   this->m_http_response_code = 0;
   this->m_internal_error_code = 0;

--- a/src/http_request_result.hpp
+++ b/src/http_request_result.hpp
@@ -14,8 +14,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #ifndef HTTP_REQUEST_RESULT_H
 #define HTTP_REQUEST_RESULT_H
 
-#include <list>
 #include <iostream>
+#include <list>
 
 using std::list;
 
@@ -37,6 +37,6 @@ public:
   list<int> get_row_ids();
   bool is_success();
 };
-}
+} // namespace snowplow
 
 #endif

--- a/src/http_request_result.hpp
+++ b/src/http_request_result.hpp
@@ -19,6 +19,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 using std::list;
 
+namespace snowplow {
 /**
  * @brief Response from HTTP requests to collector. To be used internally within tracker only.
  */
@@ -36,5 +37,6 @@ public:
   list<int> get_row_ids();
   bool is_success();
 };
+}
 
 #endif

--- a/src/payload.cpp
+++ b/src/payload.cpp
@@ -19,7 +19,7 @@ Payload::~Payload() {
   this->m_pairs.clear();
 }
 
-void Payload::add(const string & key, const string & value) {
+void Payload::add(const string &key, const string &value) {
   if (!key.empty() && !value.empty()) {
     this->m_pairs[key] = value;
   }
@@ -36,10 +36,10 @@ void Payload::add_payload(Payload p) {
   this->add_map(p.get());
 }
 
-void Payload::add_json(json j, bool base64Encode, const string & encoded, const string & not_encoded) {
+void Payload::add_json(json j, bool base64Encode, const string &encoded, const string &not_encoded) {
   if (base64Encode) {
     string json_str = j.dump();
-    this->add(encoded, base64_encode((const unsigned char *) json_str.c_str(), json_str.length()));
+    this->add(encoded, base64_encode((const unsigned char *)json_str.c_str(), json_str.length()));
   } else {
     this->add(not_encoded, j.dump());
   }

--- a/src/payload.cpp
+++ b/src/payload.cpp
@@ -13,6 +13,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "payload.hpp"
 
+using namespace snowplow;
+
 Payload::~Payload() {
   this->m_pairs.clear();
 }

--- a/src/payload.hpp
+++ b/src/payload.hpp
@@ -14,13 +14,13 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #ifndef PAYLOAD_H
 #define PAYLOAD_H
 
+#include "../include/base64.hpp"
+#include "../include/json.hpp"
 #include <map>
 #include <string>
-#include "../include/json.hpp"
-#include "../include/base64.hpp"
 
-using std::string;
 using std::map;
+using std::string;
 using json = nlohmann::json;
 
 namespace snowplow {
@@ -36,43 +36,43 @@ public:
 
   /**
    * @brief Add a property to the payload.
-   * 
+   *
    * @param key Property key
    * @param value Property value
    */
-  void add(const string & key, const string & value);
+  void add(const string &key, const string &value);
 
   /**
    * @brief Add a map of properties to the payload.
-   * 
+   *
    * @param pairs Key-value pairs
    */
   void add_map(map<string, string> pairs);
 
   /**
    * @brief Add properties from another payload.
-   * 
+   *
    * @param p Payload to add values from
    */
   void add_payload(Payload p);
 
   /**
    * @brief Add self-describing JSON data to the payload.
-   * 
+   *
    * @param j Self-describing JSON
    * @param base64Encode Should the data be base64 encoded
    * @param encoded Key for encoded data
    * @param not_encoded Key for not-encoded data
    */
-  void add_json(json j, bool base64Encode, const string & encoded, const string & not_encoded);
+  void add_json(json j, bool base64Encode, const string &encoded, const string &not_encoded);
 
   /**
    * @brief Get the payload key-value pairs.
-   * 
+   *
    * @return Payload as key-value pairs
    */
   map<string, string> get();
 };
-}
+} // namespace snowplow
 
 #endif

--- a/src/payload.hpp
+++ b/src/payload.hpp
@@ -23,6 +23,7 @@ using std::string;
 using std::map;
 using json = nlohmann::json;
 
+namespace snowplow {
 /**
  * @brief Snowplow event payload with event properties.
  */
@@ -72,5 +73,6 @@ public:
    */
   map<string, string> get();
 };
+}
 
 #endif

--- a/src/self_describing_json.cpp
+++ b/src/self_describing_json.cpp
@@ -15,7 +15,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 using namespace snowplow;
 
-SelfDescribingJson::SelfDescribingJson(const string & schema, const json & data) {
+SelfDescribingJson::SelfDescribingJson(const string &schema, const json &data) {
   json sdj;
   sdj[SNOWPLOW_SCHEMA] = schema;
   sdj[SNOWPLOW_DATA] = data;

--- a/src/self_describing_json.cpp
+++ b/src/self_describing_json.cpp
@@ -13,6 +13,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "self_describing_json.hpp"
 
+using namespace snowplow;
+
 SelfDescribingJson::SelfDescribingJson(const string & schema, const json & data) {
   json sdj;
   sdj[SNOWPLOW_SCHEMA] = schema;

--- a/src/self_describing_json.hpp
+++ b/src/self_describing_json.hpp
@@ -21,6 +21,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 using std::string;
 using json = nlohmann::json;
 
+namespace snowplow {
 /**
  * @brief Self-describing JSON object used for defining self-describing events or custom context entities.
  */
@@ -56,5 +57,6 @@ public:
    */
   string to_string();
 };
+}
 
 #endif

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -13,6 +13,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "storage.hpp"
 
+using namespace snowplow;
 using std::string;
 using std::lock_guard;
 using std::mutex;

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -14,12 +14,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "storage.hpp"
 
 using namespace snowplow;
-using std::string;
+using std::cerr;
+using std::endl;
 using std::lock_guard;
 using std::mutex;
-using std::endl;
-using std::cerr;
 using std::runtime_error;
+using std::string;
 
 const string db_table_events = "events";
 const string db_column_events_id = "id";
@@ -34,7 +34,7 @@ const string db_column_session_data = "data";
 Storage *Storage::m_instance = 0;
 mutex Storage::m_db_get;
 
-Storage *Storage::init(const string & db_name) {
+Storage *Storage::init(const string &db_name) {
   lock_guard<mutex> guard(m_db_get);
   if (!m_instance) {
     m_instance = new Storage(db_name);
@@ -53,20 +53,20 @@ Storage *Storage::instance() {
 void Storage::close() {
   lock_guard<mutex> guard(m_db_get);
   if (m_instance) {
-    delete(m_instance);
+    delete (m_instance);
   }
   m_instance = 0;
 }
 
 // --- Constructor & Destructor
 
-Storage::Storage(const string & db_name) {
+Storage::Storage(const string &db_name) {
   sqlite3 *db;
   char *err_msg = 0;
   int rc;
 
   // Open Database connection
-  rc = sqlite3_open((const char *) db_name.c_str(), &db);
+  rc = sqlite3_open((const char *)db_name.c_str(), &db);
   if (rc) {
     throw runtime_error((string) "FATAL: Cannot open database: " + sqlite3_errmsg(db));
   }
@@ -75,7 +75,7 @@ Storage::Storage(const string & db_name) {
 
   // WAL query
   string wal_query = "PRAGMA journal_mode=WAL;";
-  rc = sqlite3_exec(this->m_db, (const char *) wal_query.c_str(), NULL, NULL, &err_msg);
+  rc = sqlite3_exec(this->m_db, (const char *)wal_query.c_str(), NULL, NULL, &err_msg);
   if (rc != SQLITE_OK) {
     string err = "FATAL: Cannot enable WAL: " + string(err_msg);
     sqlite3_free(err_msg);
@@ -83,14 +83,14 @@ Storage::Storage(const string & db_name) {
   }
 
   // Create events table query
-  string create_events_query = 
-    "CREATE TABLE IF NOT EXISTS " + db_table_events + "(" +
+  string create_events_query =
+      "CREATE TABLE IF NOT EXISTS " + db_table_events + "(" +
       db_column_events_id + " INTEGER PRIMARY KEY, " +
       db_column_events_data + " STRING" +
-    ");";
+      ");";
 
   // Make new events table
-  rc = sqlite3_exec(this->m_db, (const char *) create_events_query.c_str(), NULL, NULL, &err_msg);
+  rc = sqlite3_exec(this->m_db, (const char *)create_events_query.c_str(), NULL, NULL, &err_msg);
   if (rc != SQLITE_OK) {
     cerr << "FATAL: Cannot create events table: " << err_msg << endl;
     string err = "FATAL: Cannot create events table: " + string(err_msg);
@@ -99,14 +99,14 @@ Storage::Storage(const string & db_name) {
   }
 
   // Create session table query
-  string create_sessions_query = 
-    "CREATE TABLE IF NOT EXISTS " + db_table_session + "(" +
+  string create_sessions_query =
+      "CREATE TABLE IF NOT EXISTS " + db_table_session + "(" +
       db_column_session_id + " INTEGER PRIMARY KEY, " +
       db_column_session_data + " STRING" +
-    ");";
+      ");";
 
   // Make new session table
-  rc = sqlite3_exec(this->m_db, (const char *) create_sessions_query.c_str(), NULL, NULL, &err_msg);
+  rc = sqlite3_exec(this->m_db, (const char *)create_sessions_query.c_str(), NULL, NULL, &err_msg);
   if (rc != SQLITE_OK) {
     cerr << "FATAL: Cannot create sessions table: " << err_msg << endl;
     string err = "FATAL: Cannot create sessions table: " + string(err_msg);
@@ -115,13 +115,13 @@ Storage::Storage(const string & db_name) {
   }
 
   // Insert query
-  string insert_query = 
-    "INSERT INTO " + db_table_events + "(" +
+  string insert_query =
+      "INSERT INTO " + db_table_events + "(" +
       db_column_events_data +
-    ") values(?1);";
+      ") values(?1);";
 
   // Prepare insert statement
-  rc = sqlite3_prepare_v2(this->m_db, (const char *) insert_query.c_str(), -1, &this->m_add_stmt, NULL);
+  rc = sqlite3_prepare_v2(this->m_db, (const char *)insert_query.c_str(), -1, &this->m_add_stmt, NULL);
   if (rc != SQLITE_OK) {
     throw runtime_error("FATAL: Cannot prepare event insert statement: " + std::to_string(rc));
   }
@@ -136,7 +136,7 @@ Storage::~Storage() {
 
 void Storage::insert_payload(Payload payload) {
   lock_guard<mutex> guard(this->m_db_access);
-  
+
   int rc;
 
   string payload_str = Utils::serialize_payload(payload);
@@ -162,16 +162,16 @@ void Storage::insert_payload(Payload payload) {
 
 void Storage::insert_update_session(json session_data) {
   lock_guard<mutex> guard(this->m_db_access);
-  
+
   int rc;
   sqlite3_stmt *insert_stmt;
 
-  string insert_query = 
-    "INSERT OR REPLACE INTO " + db_table_session + "(" +
+  string insert_query =
+      "INSERT OR REPLACE INTO " + db_table_session + "(" +
       db_column_session_id + "," + db_column_session_data +
-    ") values(?1, ?2);";
+      ") values(?1, ?2);";
 
-  rc = sqlite3_prepare_v2(this->m_db, (const char *) insert_query.c_str(), -1, &insert_stmt, NULL);
+  rc = sqlite3_prepare_v2(this->m_db, (const char *)insert_query.c_str(), -1, &insert_stmt, NULL);
   if (rc != SQLITE_OK) {
     cerr << "ERROR: Cannot prepare session insert statement: " << std::to_string(rc) << endl;
     return;
@@ -208,52 +208,52 @@ void Storage::insert_update_session(json session_data) {
 // --- SELECT
 
 static int select_event_callback(void *data, int argc, char **argv, char **az_col_name) {
-   int i, id = 0;
-   list<Storage::EventRow>* data_list = (list<Storage::EventRow>*)data;
-   Payload event;
+  int i, id = 0;
+  list<Storage::EventRow> *data_list = (list<Storage::EventRow> *)data;
+  Payload event;
 
-   for (i = 0; i < argc; i++) {
-      if (az_col_name[i] == db_column_events_id) {
-        id = std::stoi(argv[i] ? argv[i] : "-1");
-      } else if (az_col_name[i] == db_column_events_data) {
-        event = Utils::deserialize_json_str(argv[i] ? argv[i] : "");
-      }
-   }
+  for (i = 0; i < argc; i++) {
+    if (az_col_name[i] == db_column_events_id) {
+      id = std::stoi(argv[i] ? argv[i] : "-1");
+    } else if (az_col_name[i] == db_column_events_data) {
+      event = Utils::deserialize_json_str(argv[i] ? argv[i] : "");
+    }
+  }
 
-   Storage::EventRow event_row;
-   event_row.id = id;
-   event_row.event = event;
-   data_list->push_back(event_row);
-   return 0;
+  Storage::EventRow event_row;
+  event_row.id = id;
+  event_row.event = event;
+  data_list->push_back(event_row);
+  return 0;
 }
 
-void Storage::select_all_event_rows(list<Storage::EventRow>* event_list) {
+void Storage::select_all_event_rows(list<Storage::EventRow> *event_list) {
   lock_guard<mutex> guard(this->m_db_access);
 
   int rc;
   char *err_msg = 0;
 
   string select_all_query =
-    "SELECT * FROM " + db_table_events + ";";
+      "SELECT * FROM " + db_table_events + ";";
 
-  rc = sqlite3_exec(this->m_db, (const char *) select_all_query.c_str(), select_event_callback, (void*)event_list, &err_msg);
+  rc = sqlite3_exec(this->m_db, (const char *)select_all_query.c_str(), select_event_callback, (void *)event_list, &err_msg);
   if (rc != SQLITE_OK) {
     cerr << "ERROR: Failed to execute select_all_query: " << rc << "; " << err_msg << endl;
     sqlite3_free(err_msg);
   }
 }
 
-void Storage::select_event_row_range(list<Storage::EventRow>* event_list, int range) {
+void Storage::select_event_row_range(list<Storage::EventRow> *event_list, int range) {
   lock_guard<mutex> guard(this->m_db_access);
 
   int rc;
   char *err_msg = 0;
 
   string select_range_query =
-    "SELECT * FROM " + db_table_events + " " +
-    "ORDER BY " + db_column_events_id + " ASC LIMIT " + std::to_string(range) + ";";
+      "SELECT * FROM " + db_table_events + " " +
+      "ORDER BY " + db_column_events_id + " ASC LIMIT " + std::to_string(range) + ";";
 
-  rc = sqlite3_exec(this->m_db, (const char *) select_range_query.c_str(), select_event_callback, (void*)event_list, &err_msg);
+  rc = sqlite3_exec(this->m_db, (const char *)select_range_query.c_str(), select_event_callback, (void *)event_list, &err_msg);
   if (rc != SQLITE_OK) {
     cerr << "ERROR: Failed to execute select_range_query: " << rc << "; " << err_msg << endl;
     sqlite3_free(err_msg);
@@ -261,31 +261,31 @@ void Storage::select_event_row_range(list<Storage::EventRow>* event_list, int ra
 }
 
 static int select_session_callback(void *data, int argc, char **argv, char **az_col_name) {
-   int i;
-   list<json>* data_list = (list<json>*)data;
-   json session_data;
+  int i;
+  list<json> *data_list = (list<json> *)data;
+  json session_data;
 
-   for (i = 0; i < argc; i++) {
-      if (az_col_name[i] == db_column_session_data) {
-        session_data = json::parse(argv[i] ? argv[i] : "");
-        break;
-      }
-   }
+  for (i = 0; i < argc; i++) {
+    if (az_col_name[i] == db_column_session_data) {
+      session_data = json::parse(argv[i] ? argv[i] : "");
+      break;
+    }
+  }
 
-   data_list->push_back(session_data);
-   return 0;
+  data_list->push_back(session_data);
+  return 0;
 }
 
-void Storage::select_all_session_rows(list<json>* session_list) {
+void Storage::select_all_session_rows(list<json> *session_list) {
   lock_guard<mutex> guard(this->m_db_access);
 
   int rc;
   char *err_msg = 0;
 
   string select_all_query =
-    "SELECT * FROM " + db_table_session + ";";
+      "SELECT * FROM " + db_table_session + ";";
 
-  rc = sqlite3_exec(this->m_db, (const char *) select_all_query.c_str(), select_session_callback, (void*)session_list, &err_msg);
+  rc = sqlite3_exec(this->m_db, (const char *)select_all_query.c_str(), select_session_callback, (void *)session_list, &err_msg);
   if (rc != SQLITE_OK) {
     cerr << "ERROR: Failed to execute select_all_query: " << rc << "; " << err_msg << endl;
     sqlite3_free(err_msg);
@@ -301,26 +301,26 @@ void Storage::delete_all_event_rows() {
   char *err_msg = 0;
 
   string delete_all_query =
-    "DELETE FROM " + db_table_events + ";";
+      "DELETE FROM " + db_table_events + ";";
 
-  rc = sqlite3_exec(this->m_db, (const char *) delete_all_query.c_str(), NULL, NULL, &err_msg);
+  rc = sqlite3_exec(this->m_db, (const char *)delete_all_query.c_str(), NULL, NULL, &err_msg);
   if (rc != SQLITE_OK) {
     cerr << "ERROR: Failed to execute delete_all_query: " << rc << "; " << err_msg << endl;
     sqlite3_free(err_msg);
   }
 }
 
-void Storage::delete_event_row_ids(list<int>* id_list) {
+void Storage::delete_event_row_ids(list<int> *id_list) {
   lock_guard<mutex> guard(this->m_db_access);
-  
+
   int rc;
   char *err_msg = 0;
 
   string delete_range_query =
-    "DELETE FROM " + db_table_events + " " +
-    "WHERE " + db_column_events_id + " in (" + Utils::int_list_to_string(id_list, ",") + ");";
+      "DELETE FROM " + db_table_events + " " +
+      "WHERE " + db_column_events_id + " in (" + Utils::int_list_to_string(id_list, ",") + ");";
 
-  rc = sqlite3_exec(this->m_db, (const char *) delete_range_query.c_str(), NULL, NULL, &err_msg);
+  rc = sqlite3_exec(this->m_db, (const char *)delete_range_query.c_str(), NULL, NULL, &err_msg);
   if (rc != SQLITE_OK) {
     cerr << "ERROR: Failed to execute delete_range_query: " << rc << "; " << err_msg << endl;
     sqlite3_free(err_msg);
@@ -334,9 +334,9 @@ void Storage::delete_all_session_rows() {
   char *err_msg = 0;
 
   string delete_all_query =
-    "DELETE FROM " + db_table_session + ";";
+      "DELETE FROM " + db_table_session + ";";
 
-  rc = sqlite3_exec(this->m_db, (const char *) delete_all_query.c_str(), NULL, NULL, &err_msg);
+  rc = sqlite3_exec(this->m_db, (const char *)delete_all_query.c_str(), NULL, NULL, &err_msg);
   if (rc != SQLITE_OK) {
     cerr << "ERROR: Failed to execute delete_all_query: " << rc << "; " << err_msg << endl;
     sqlite3_free(err_msg);

--- a/src/storage.hpp
+++ b/src/storage.hpp
@@ -30,6 +30,7 @@ using std::string;
 using std::list;
 using json = nlohmann::json;
 
+namespace snowplow {
 /**
  * @brief Tracker internal SQLite storage for events and session information. To be used internally within tracker only.
  * 
@@ -66,5 +67,6 @@ public:
   void delete_all_session_rows();
   string get_db_name();
 };
+}
 
 #endif

--- a/src/subject.cpp
+++ b/src/subject.cpp
@@ -15,7 +15,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 using namespace snowplow;
 
-void Subject::set_user_id(const string & user_id) {
+void Subject::set_user_id(const string &user_id) {
   this->m_payload.add(SNOWPLOW_UID, user_id);
 }
 
@@ -33,15 +33,15 @@ void Subject::set_color_depth(int depth) {
   this->m_payload.add(SNOWPLOW_COLOR_DEPTH, std::to_string(depth));
 }
 
-void Subject::set_timezone(const string & timezone) {
+void Subject::set_timezone(const string &timezone) {
   this->m_payload.add(SNOWPLOW_TIMEZONE, timezone);
 }
 
-void Subject::set_language(const string & language) {
+void Subject::set_language(const string &language) {
   this->m_payload.add(SNOWPLOW_LANGUAGE, language);
 }
 
-void Subject::set_useragent(const string & useragent) {
+void Subject::set_useragent(const string &useragent) {
   this->m_payload.add(SNOWPLOW_USERAGENT, useragent);
 }
 

--- a/src/subject.cpp
+++ b/src/subject.cpp
@@ -13,6 +13,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "subject.hpp"
 
+using namespace snowplow;
+
 void Subject::set_user_id(const string & user_id) {
   this->m_payload.add(SNOWPLOW_UID, user_id);
 }

--- a/src/subject.hpp
+++ b/src/subject.hpp
@@ -22,6 +22,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 using std::map;
 using std::string;
 
+namespace snowplow {
 /**
  * @brief Defines additional information about your application's environment, current user and so on, to be sent to with each tracked event.
  */
@@ -88,5 +89,6 @@ public:
    */
   map<string, string> get_map();
 };
+}
 
 #endif

--- a/src/tracker.cpp
+++ b/src/tracker.cpp
@@ -13,6 +13,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "tracker.hpp"
 
+using namespace snowplow;
 using std::to_string;
 using std::lock_guard;
 using std::invalid_argument;

--- a/src/tracker.cpp
+++ b/src/tracker.cpp
@@ -14,18 +14,18 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "tracker.hpp"
 
 using namespace snowplow;
-using std::to_string;
-using std::lock_guard;
 using std::invalid_argument;
+using std::lock_guard;
 using std::runtime_error;
+using std::to_string;
 
 // --- Static Singleton Access
 
 Tracker *Tracker::m_instance = 0;
 mutex Tracker::m_tracker_get;
 
-Tracker *Tracker::init(Emitter &emitter, Subject *subject, ClientSession *client_session, string *platform, string *app_id, 
-  string *name_space, bool *use_base64, bool *desktop_context) {
+Tracker *Tracker::init(Emitter &emitter, Subject *subject, ClientSession *client_session, string *platform, string *app_id,
+                       string *name_space, bool *use_base64, bool *desktop_context) {
 
   lock_guard<mutex> guard(m_tracker_get);
   if (!m_instance) {
@@ -45,15 +45,15 @@ Tracker *Tracker::instance() {
 void Tracker::close() {
   lock_guard<mutex> guard(m_tracker_get);
   if (m_instance) {
-    delete(m_instance);
+    delete (m_instance);
   }
   m_instance = 0;
 }
 
 // --- Constructor & Destructor
 
-Tracker::Tracker(Emitter &emitter, Subject *subject, ClientSession *client_session, string *platform, string *app_id, 
-  string *name_space, bool *use_base64, bool *desktop_context) : m_emitter(emitter), m_client_session(client_session) {
+Tracker::Tracker(Emitter &emitter, Subject *subject, ClientSession *client_session, string *platform, string *app_id,
+                 string *name_space, bool *use_base64, bool *desktop_context) : m_emitter(emitter), m_client_session(client_session) {
 
   this->m_subject = subject;
   this->m_platform = (platform != NULL ? *platform : "srv");
@@ -92,7 +92,7 @@ void Tracker::set_subject(Subject *subject) {
 
 // --- Event Tracking
 
-void Tracker::track(Payload payload, const string & event_id, vector<SelfDescribingJson> & contexts) { 
+void Tracker::track(Payload payload, const string &event_id, vector<SelfDescribingJson> &contexts) {
   // Add standard KV Pairs
   payload.add(SNOWPLOW_TRACKER_VERSION, SNOWPLOW_TRACKER_VERSION_LABEL);
   payload.add(SNOWPLOW_PLATFORM, this->m_platform);
@@ -130,10 +130,10 @@ void Tracker::track(Payload payload, const string & event_id, vector<SelfDescrib
 
 void Tracker::track_struct_event(StructuredEvent se) {
   if (se.action == "") {
-    throw invalid_argument("Action is required"); 
+    throw invalid_argument("Action is required");
   }
-  if (se.category == "") { 
-    throw invalid_argument("Category is required"); 
+  if (se.category == "") {
+    throw invalid_argument("Category is required");
   }
 
   Payload p;
@@ -188,10 +188,10 @@ void Tracker::track_screen_view(Tracker::ScreenViewEvent sve) {
 
 void Tracker::track_timing(TimingEvent te) {
   if (te.category == "") {
-    throw invalid_argument("Category is required"); 
+    throw invalid_argument("Category is required");
   }
-  if (te.variable == "") { 
-    throw invalid_argument("Variable is required"); 
+  if (te.variable == "") {
+    throw invalid_argument("Variable is required");
   }
 
   json data;
@@ -244,7 +244,7 @@ Tracker::StructuredEvent::StructuredEvent(string category, string action) {
   this->value = NULL;
 }
 
-Tracker::SelfDescribingEvent::SelfDescribingEvent(SelfDescribingJson event): event(event) {
+Tracker::SelfDescribingEvent::SelfDescribingEvent(SelfDescribingJson event) : event(event) {
   this->event_id = Utils::get_uuid4();
   this->timestamp = Utils::get_unix_epoch_ms();
   this->true_timestamp = NULL;

--- a/src/tracker.hpp
+++ b/src/tracker.hpp
@@ -23,6 +23,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 using std::string;
 using std::vector;
 
+namespace snowplow {
 /**
  * @brief Singleton object that provides an interface to track Snowplow events.
  */
@@ -344,5 +345,6 @@ private:
   bool m_use_base64;
   bool m_desktop_context;
 };
+}
 
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -14,28 +14,28 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "utils.hpp"
 
 using namespace snowplow;
-using std::runtime_error;
-using std::stringstream;
-using std::ostringstream;
 using std::hex;
-using std::uppercase;
 using std::nouppercase;
-using std::to_string;
+using std::ostringstream;
+using std::runtime_error;
 using std::setw;
+using std::stringstream;
+using std::to_string;
+using std::uppercase;
 using std::chrono::duration_cast;
-using std::chrono::system_clock;
 using std::chrono::milliseconds;
+using std::chrono::system_clock;
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
 
 string Utils::get_uuid4() {
-  UUID uuid = { 0 };
+  UUID uuid = {0};
   string uid;
 
   ::UuidCreate(&uuid);
   RPC_CSTR szUuid = NULL;
   if (::UuidToStringA(&uuid, &szUuid) == RPC_S_OK) {
-    uid = (char*)szUuid;
+    uid = (char *)szUuid;
     ::RpcStringFreeA(&szUuid);
   } else {
     throw runtime_error("FATAL: Could not generate unique UUID");
@@ -61,7 +61,7 @@ string Utils::get_uuid4() {
 
 #endif
 
-string Utils::int_list_to_string(list<int>* int_list, const string & delimiter) {
+string Utils::int_list_to_string(list<int> *int_list, const string &delimiter) {
   stringstream s;
   int i;
   list<int>::iterator it;
@@ -107,7 +107,7 @@ string Utils::url_encode(string value) {
       continue;
     }
     escaped << uppercase;
-    escaped << '%' << uppercase << setw(2) << int((unsigned char) c);
+    escaped << '%' << uppercase << setw(2) << int((unsigned char)c);
     escaped << nouppercase;
   }
 
@@ -119,10 +119,10 @@ string Utils::serialize_payload(Payload payload) {
   return j_map.dump();
 }
 
-Payload Utils::deserialize_json_str(const string & json_str) {
+Payload Utils::deserialize_json_str(const string &json_str) {
   Payload p;
   json j = json::parse(json_str);
-  
+
   for (json::iterator it = j.begin(); it != j.end(); ++it) {
     p.add(it.key(), it.value());
   }
@@ -131,7 +131,7 @@ Payload Utils::deserialize_json_str(const string & json_str) {
 }
 
 unsigned long long Utils::get_unix_epoch_ms() {
-  return duration_cast<milliseconds> (system_clock::now().time_since_epoch()).count();
+  return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
 }
 
 // --- Desktop Context
@@ -191,7 +191,7 @@ bool Utils::get_os_is_64bit() {
 #elif defined(_WIN32)
   BOOL f64 = FALSE;
   return IsWow64Process(GetCurrentProcess(), &f64) && f64;
-#else 
+#else
   return false;
 #endif
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,6 +13,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "utils.hpp"
 
+using namespace snowplow;
 using std::runtime_error;
 using std::stringstream;
 using std::ostringstream;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -47,6 +47,7 @@ using std::list;
 using std::string;
 using json = nlohmann::json;
 
+namespace snowplow {
 /**
  * @brief Tracker internal utility functions.
  */
@@ -70,5 +71,6 @@ public:
 private:
   static SelfDescribingJson *m_desktop_context;
 };
+}
 
 #endif

--- a/src/utils_macos.mm
+++ b/src/utils_macos.mm
@@ -17,7 +17,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 @implementation UtilsMacOS
 
-string get_os_version_objc() {
+string snowplow::get_os_version_objc() {
     return ([[UtilsMacOS getOSVersion] UTF8String]);
 }
 

--- a/src/utils_macos_interface.h
+++ b/src/utils_macos_interface.h
@@ -18,6 +18,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 using std::string;
 
+namespace snowplow {
 string get_os_version_objc();
+}
 
 #endif

--- a/test/client_session_test.cpp
+++ b/test/client_session_test.cpp
@@ -11,14 +11,14 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "catch.hpp"
 #include "../src/client_session.hpp"
 #include "../src/storage.hpp"
+#include "catch.hpp"
 #include <thread>
 
 using namespace snowplow;
-using std::this_thread::sleep_for;
 using std::chrono::milliseconds;
+using std::this_thread::sleep_for;
 
 TEST_CASE("client_session") {
   SECTION("The Session doesn't change for subsequent tracked events") {
@@ -48,7 +48,7 @@ TEST_CASE("client_session") {
 
     SelfDescribingJson session_json = cs.update_and_get_session_context("event-id");
     REQUIRE("iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1" == session_json.get()[SNOWPLOW_SCHEMA].get<std::string>());
-    
+
     json data = session_json.get()[SNOWPLOW_DATA];
 
     REQUIRE("event-id" == data[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
@@ -83,7 +83,7 @@ TEST_CASE("client_session") {
 
     SelfDescribingJson session_json1 = cs1.update_and_get_session_context("event-id2");
     REQUIRE("iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1" == session_json1.get()[SNOWPLOW_SCHEMA].get<std::string>());
-    
+
     json data1 = session_json1.get()[SNOWPLOW_DATA];
 
     REQUIRE("event-id2" == data1[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
@@ -112,7 +112,7 @@ TEST_CASE("client_session") {
 
     SelfDescribingJson session_json = cs.update_and_get_session_context("event-id3");
     REQUIRE("iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1" == session_json.get()[SNOWPLOW_SCHEMA].get<std::string>());
-    
+
     json data = session_json.get()[SNOWPLOW_DATA];
 
     REQUIRE("event-id3" == data[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());

--- a/test/client_session_test.cpp
+++ b/test/client_session_test.cpp
@@ -16,6 +16,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../src/storage.hpp"
 #include <thread>
 
+using namespace snowplow;
 using std::this_thread::sleep_for;
 using std::chrono::milliseconds;
 

--- a/test/cracked_url_test.cpp
+++ b/test/cracked_url_test.cpp
@@ -11,8 +11,8 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "catch.hpp"
 #include "../src/cracked_url.hpp"
+#include "catch.hpp"
 
 using namespace snowplow;
 

--- a/test/cracked_url_test.cpp
+++ b/test/cracked_url_test.cpp
@@ -14,6 +14,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "catch.hpp"
 #include "../src/cracked_url.hpp"
 
+using namespace snowplow;
+
 TEST_CASE("cracked_url") {
   SECTION("URL cracking works for the current build target") {
     CrackedUrl c("http://google.com/search/tp2");

--- a/test/emitter_test.cpp
+++ b/test/emitter_test.cpp
@@ -11,8 +11,8 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "catch.hpp"
 #include "../src/emitter.hpp"
+#include "catch.hpp"
 
 using namespace snowplow;
 using std::invalid_argument;
@@ -26,29 +26,25 @@ TEST_CASE("emitter") {
 
     try {
       Emitter emitter("http://com.acme.collector", Emitter::Method::POST, Emitter::Protocol::HTTP, 500, 52000, 51000, "test-emitter.db");
-    }
-    catch (invalid_argument) {
+    } catch (invalid_argument) {
       inv_arg_http = true;
     }
 
     try {
       Emitter emitter("https://com.acme.collector", Emitter::Method::POST, Emitter::Protocol::HTTP, 500, 52000, 51000, "test-emitter.db");
-    }
-    catch (invalid_argument) {
+    } catch (invalid_argument) {
       inv_arg_https = true;
     }
 
     try {
       Emitter emitter("HTTP://com.acme.collector", Emitter::Method::POST, Emitter::Protocol::HTTP, 500, 52000, 51000, "test-emitter.db");
-    }
-    catch (invalid_argument) {
+    } catch (invalid_argument) {
       inv_arg_http_case = true;
     }
 
     try {
       Emitter emitter("HTTPS://com.acme.collector", Emitter::Method::POST, Emitter::Protocol::HTTP, 500, 52000, 51000, "test-emitter.db");
-    }
-    catch (invalid_argument) {
+    } catch (invalid_argument) {
       inv_arg_https_case = true;
     }
 
@@ -95,7 +91,7 @@ TEST_CASE("emitter") {
 
     bool inv_argument_empty_uri = false;
     try {
-      Emitter emitter_2("", Emitter::Method::GET, Emitter::Protocol::HTTPS, 500, 52000, 51000, "test-emitter.db"); 
+      Emitter emitter_2("", Emitter::Method::GET, Emitter::Protocol::HTTPS, 500, 52000, 51000, "test-emitter.db");
     } catch (invalid_argument) {
       inv_argument_empty_uri = true;
     }
@@ -103,7 +99,7 @@ TEST_CASE("emitter") {
 
     bool inv_argument_bad_url = false;
     try {
-      Emitter emitter_3("../:random../gibber", Emitter::Method::GET, Emitter::Protocol::HTTPS, 500, 52000, 51000, "test-emitter.db"); 
+      Emitter emitter_3("../:random../gibber", Emitter::Method::GET, Emitter::Protocol::HTTPS, 500, 52000, 51000, "test-emitter.db");
     } catch (invalid_argument) {
       inv_argument_bad_url = true;
     }
@@ -127,7 +123,7 @@ TEST_CASE("emitter") {
     list<HttpClient::Request> requests = HttpClient::get_requests_list();
     REQUIRE(0 != requests.size());
 
-    list<Storage::EventRow>* event_list = new list<Storage::EventRow>;
+    list<Storage::EventRow> *event_list = new list<Storage::EventRow>;
     Storage::instance()->select_all_event_rows(event_list);
     REQUIRE(0 == event_list->size());
     event_list->clear();
@@ -146,7 +142,7 @@ TEST_CASE("emitter") {
 
     e.stop();
     HttpClient::reset();
-    delete(event_list);
+    delete (event_list);
   }
 
   SECTION("Emitter should track and remove only successful events from the database for POST requests") {
@@ -164,7 +160,7 @@ TEST_CASE("emitter") {
     list<HttpClient::Request> requests = HttpClient::get_requests_list();
     REQUIRE(0 != requests.size());
 
-    list<Storage::EventRow>* event_list = new list<Storage::EventRow>;
+    list<Storage::EventRow> *event_list = new list<Storage::EventRow>;
     Storage::instance()->select_all_event_rows(event_list);
     REQUIRE(0 == event_list->size());
     event_list->clear();
@@ -211,9 +207,8 @@ TEST_CASE("emitter") {
     event_list->clear();
 
     HttpClient::reset();
-    delete(event_list);
+    delete (event_list);
   }
 
 #endif
-
 }

--- a/test/emitter_test.cpp
+++ b/test/emitter_test.cpp
@@ -14,6 +14,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "catch.hpp"
 #include "../src/emitter.hpp"
 
+using namespace snowplow;
 using std::invalid_argument;
 
 TEST_CASE("emitter") {

--- a/test/http_client_test.cpp
+++ b/test/http_client_test.cpp
@@ -14,6 +14,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "catch.hpp"
 #include "../src/http_client.hpp"
 
+using namespace snowplow;
+
 #if defined(SNOWPLOW_TEST_SUITE)
 
 #define HTTP_TEST_URL_GET "http://com.acme.collector/i"

--- a/test/http_client_test.cpp
+++ b/test/http_client_test.cpp
@@ -11,8 +11,8 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "catch.hpp"
 #include "../src/http_client.hpp"
+#include "catch.hpp"
 
 using namespace snowplow;
 

--- a/test/http_request_result_test.cpp
+++ b/test/http_request_result_test.cpp
@@ -14,6 +14,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "catch.hpp"
 #include "../src/http_request_result.hpp"
 
+using namespace snowplow;
+
 TEST_CASE("http_request_result") {
   SECTION("is_success should be set only if the error code is zero and the response code is 200") {
     HttpRequestResult httpRequestResult(0, 200, list<int>(), false);

--- a/test/http_request_result_test.cpp
+++ b/test/http_request_result_test.cpp
@@ -11,8 +11,8 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "catch.hpp"
 #include "../src/http_request_result.hpp"
+#include "catch.hpp"
 
 using namespace snowplow;
 

--- a/test/payload_test.cpp
+++ b/test/payload_test.cpp
@@ -11,11 +11,11 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include <map>
-#include <string>
-#include "catch.hpp"
 #include "../include/json.hpp"
 #include "../src/payload.hpp"
+#include "catch.hpp"
+#include <map>
+#include <string>
 
 using namespace snowplow;
 using json = nlohmann::json;
@@ -35,7 +35,7 @@ TEST_CASE("payload") {
   }
 
   SECTION("add_map should add all valid non-empty kv pairs") {
-    map<string, string> test_map = { { "hello", "world" }, { "e", "pv" } };
+    map<string, string> test_map = {{"hello", "world"}, {"e", "pv"}};
     pl.add_map(test_map);
     REQUIRE(pl.get().size() == 2);
     REQUIRE(pl.get()["hello"] == "world");

--- a/test/payload_test.cpp
+++ b/test/payload_test.cpp
@@ -17,6 +17,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../include/json.hpp"
 #include "../src/payload.hpp"
 
+using namespace snowplow;
 using json = nlohmann::json;
 
 TEST_CASE("payload") {

--- a/test/self_describing_json_test.cpp
+++ b/test/self_describing_json_test.cpp
@@ -11,8 +11,8 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "catch.hpp"
 #include "../src/self_describing_json.hpp"
+#include "catch.hpp"
 
 using namespace snowplow;
 

--- a/test/self_describing_json_test.cpp
+++ b/test/self_describing_json_test.cpp
@@ -14,6 +14,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "catch.hpp"
 #include "../src/self_describing_json.hpp"
 
+using namespace snowplow;
+
 TEST_CASE("self_describing_json") {
   json j = "{\"test\":\"event\"}"_json;
   SelfDescribingJson sdj("iglu:com.acme/test/jsonschema/1-0-0", j);

--- a/test/storage_test.cpp
+++ b/test/storage_test.cpp
@@ -11,8 +11,8 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "catch.hpp"
 #include "../src/storage.hpp"
+#include "catch.hpp"
 
 using namespace snowplow;
 using std::runtime_error;
@@ -28,9 +28,9 @@ TEST_CASE("storage") {
 
     bool runtime_error_not_init = false;
     try {
-        Storage::instance();
+      Storage::instance();
     } catch (runtime_error) {
-        runtime_error_not_init = true;
+      runtime_error_not_init = true;
     }
     REQUIRE(runtime_error_not_init == true);
 
@@ -38,9 +38,9 @@ TEST_CASE("storage") {
 
     runtime_error_not_init = false;
     try {
-        Storage::instance();
+      Storage::instance();
     } catch (runtime_error) {
-        runtime_error_not_init = true;
+      runtime_error_not_init = true;
     }
     REQUIRE(runtime_error_not_init == false);
   }
@@ -50,9 +50,9 @@ TEST_CASE("storage") {
 
     bool runtime_error_bad_db_name = false;
     try {
-        Storage::init("~/");
+      Storage::init("~/");
     } catch (runtime_error) {
-        runtime_error_bad_db_name = true;
+      runtime_error_bad_db_name = true;
     }
     REQUIRE(runtime_error_bad_db_name == true);
 
@@ -71,7 +71,7 @@ TEST_CASE("storage") {
     }
 
     // SELECT one row
-    list<Storage::EventRow>* event_list = new list<Storage::EventRow>;
+    list<Storage::EventRow> *event_list = new list<Storage::EventRow>;
     storage->select_all_event_rows(event_list);
     REQUIRE(50 == event_list->size());
 
@@ -87,16 +87,16 @@ TEST_CASE("storage") {
     event_list->clear();
     storage->select_event_row_range(event_list, 5);
     REQUIRE(5 == event_list->size());
-    
+
     // DELETE rows by id
-    list<int>* id_list = new list<int>;
+    list<int> *id_list = new list<int>;
     for (list<Storage::EventRow>::iterator it = event_list->begin(); it != event_list->end(); ++it) {
       id_list->push_back(it->id);
     }
     storage->delete_event_row_ids(id_list);
     event_list->clear();
     id_list->clear();
-    delete(id_list);
+    delete (id_list);
 
     storage->select_event_row_range(event_list, 100);
     REQUIRE(45 == event_list->size());
@@ -109,13 +109,13 @@ TEST_CASE("storage") {
     event_list->clear();
 
     // Delete memory for list
-    delete(event_list);
+    delete (event_list);
     storage->delete_all_event_rows();
     Storage::close();
   }
 
   SECTION("should be able to insert only one session object into the database") {
-    list<json>* session_rows = new list<json>;
+    list<json> *session_rows = new list<json>;
 
     // Insert and check row
     json j = "{\"storage\":\"SQLITE\",\"previousSessionId\":null}"_json;
@@ -146,7 +146,7 @@ TEST_CASE("storage") {
     session_rows->clear();
 
     // Delete memory for list
-    delete(session_rows);
+    delete (session_rows);
     storage->delete_all_session_rows();
     Storage::close();
   }

--- a/test/storage_test.cpp
+++ b/test/storage_test.cpp
@@ -14,6 +14,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "catch.hpp"
 #include "../src/storage.hpp"
 
+using namespace snowplow;
 using std::runtime_error;
 
 TEST_CASE("storage") {

--- a/test/subject_test.cpp
+++ b/test/subject_test.cpp
@@ -11,8 +11,8 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "catch.hpp"
 #include "../src/subject.hpp"
+#include "catch.hpp"
 
 using namespace snowplow;
 

--- a/test/subject_test.cpp
+++ b/test/subject_test.cpp
@@ -14,6 +14,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "catch.hpp"
 #include "../src/subject.hpp"
 
+using namespace snowplow;
+
 TEST_CASE("subject") {
   Subject sub;
   REQUIRE(sub.get_map().size() == 0);

--- a/test/tracker_test.cpp
+++ b/test/tracker_test.cpp
@@ -17,6 +17,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../src/tracker.hpp"
 #include "../src/emitter.hpp"
 
+using namespace snowplow;
 using std::to_string;
 using std::invalid_argument;
 using std::runtime_error;

--- a/test/tracker_test.cpp
+++ b/test/tracker_test.cpp
@@ -11,16 +11,16 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "catch.hpp"
-#include "../include/json.hpp"
 #include "../include/base64.hpp"
-#include "../src/tracker.hpp"
+#include "../include/json.hpp"
 #include "../src/emitter.hpp"
+#include "../src/tracker.hpp"
+#include "catch.hpp"
 
 using namespace snowplow;
-using std::to_string;
 using std::invalid_argument;
 using std::runtime_error;
+using std::to_string;
 
 TEST_CASE("tracker") {
 
@@ -44,10 +44,10 @@ TEST_CASE("tracker") {
   SECTION("Mock emitter stores payloads") {
     MockEmitter e;
 
-    e.start();    
+    e.start();
     REQUIRE(e.is_started() == true);
 
-    Payload example;   
+    Payload example;
     e.add(example);
     REQUIRE(e.get_added_payloads().size() == 1);
   }
@@ -57,9 +57,9 @@ TEST_CASE("tracker") {
   SECTION("Tracker singleton controls provide expected behaviour") {
     bool runtime_exception_on_not_init = false;
     try {
-        Tracker *t = Tracker::instance();
+      Tracker *t = Tracker::instance();
     } catch (runtime_error) {
-        runtime_exception_on_not_init = true;
+      runtime_exception_on_not_init = true;
     }
     REQUIRE(runtime_exception_on_not_init == true);
 
@@ -68,9 +68,9 @@ TEST_CASE("tracker") {
 
     runtime_exception_on_not_init = false;
     try {
-        Tracker *t = Tracker::instance();
+      Tracker *t = Tracker::instance();
     } catch (runtime_error) {
-        runtime_exception_on_not_init = true;
+      runtime_exception_on_not_init = true;
     }
     REQUIRE(runtime_exception_on_not_init == false);
 
@@ -149,7 +149,7 @@ TEST_CASE("tracker") {
   SECTION("Tracker adds default fields to each payload") {
     MockEmitter e;
     Tracker *t = Tracker::init(e, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-    
+
     REQUIRE(e.is_started() == true);
 
     vector<SelfDescribingJson> v;
@@ -178,7 +178,7 @@ TEST_CASE("tracker") {
     bool desktop_context = true;
 
     Tracker *t = Tracker::init(e, NULL, NULL, &plat, &app_id, &name_space, &base64, &desktop_context);
-    
+
     REQUIRE(e.is_started() == true);
 
     vector<SelfDescribingJson> v;
@@ -236,7 +236,7 @@ TEST_CASE("tracker") {
     REQUIRE(sve.timestamp > time_now - 1000);
     REQUIRE(sve.timestamp < time_now + 1000);
     REQUIRE(sve.true_timestamp == NULL);
-  }  
+  }
 
   SECTION("TimingEvents have appropriate defaults") {
     unsigned long long time_now = Utils::get_unix_epoch_ms();
@@ -258,19 +258,25 @@ TEST_CASE("tracker") {
     bool is_arg_exception_empty_category;
     bool is_arg_exception_empty_action;
 
-    MockEmitter e; 
+    MockEmitter e;
     Tracker *t = Tracker::init(e, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-    
+
     Tracker::StructuredEvent sv("", "hello");
 
-    try { t->track_struct_event(sv); } 
-    catch (invalid_argument) { is_arg_exception_empty_category = true; }
+    try {
+      t->track_struct_event(sv);
+    } catch (invalid_argument) {
+      is_arg_exception_empty_category = true;
+    }
 
     sv.action = "";
     sv.category = "hello";
 
-    try { t->track_struct_event(sv); }
-    catch (invalid_argument) { is_arg_exception_empty_action = true; }
+    try {
+      t->track_struct_event(sv);
+    } catch (invalid_argument) {
+      is_arg_exception_empty_action = true;
+    }
 
     REQUIRE(is_arg_exception_empty_action);
     REQUIRE(is_arg_exception_empty_category);
@@ -347,10 +353,10 @@ TEST_CASE("tracker") {
     SelfDescribingJson uej(SNOWPLOW_SCHEMA_UNSTRUCT_EVENT, sdj.get());
 
     string json = uej.to_string();
-    const unsigned char* c_json = (const unsigned char*)json.c_str();
+    const unsigned char *c_json = (const unsigned char *)json.c_str();
 
     REQUIRE(payload[SNOWPLOW_UNSTRUCTURED_ENCODED] == base64_encode(c_json, json.length()));
-    
+
     se.id = NULL;
     string name = "name";
     se.name = &name;
@@ -360,7 +366,7 @@ TEST_CASE("tracker") {
     t->track_screen_view(se);
     auto new_payload = e.get_added_payloads()[1].get();
 
-    REQUIRE(new_payload[SNOWPLOW_TRUE_TIMESTAMP] ==  to_string(ttm));
+    REQUIRE(new_payload[SNOWPLOW_TRUE_TIMESTAMP] == to_string(ttm));
 
     nlohmann::json new_expected;
     new_expected[SNOWPLOW_SV_NAME] = "name";
@@ -368,7 +374,7 @@ TEST_CASE("tracker") {
     SelfDescribingJson uej_1(SNOWPLOW_SCHEMA_UNSTRUCT_EVENT, sdj_1.get());
 
     string json_1 = uej_1.to_string();
-    const unsigned char* c_json_1 = (const unsigned char*) json_1.c_str();
+    const unsigned char *c_json_1 = (const unsigned char *)json_1.c_str();
 
     REQUIRE(new_payload[SNOWPLOW_UNSTRUCTURED_ENCODED] == base64_encode(c_json_1, json_1.length()));
 
@@ -413,7 +419,7 @@ TEST_CASE("tracker") {
     SelfDescribingJson uej(SNOWPLOW_SCHEMA_UNSTRUCT_EVENT, sdj.get());
 
     string json = uej.to_string();
-    const unsigned char* c_json = (const unsigned char*)json.c_str();
+    const unsigned char *c_json = (const unsigned char *)json.c_str();
 
     REQUIRE(payload[SNOWPLOW_UNSTRUCTURED_ENCODED] == base64_encode(c_json, json.length()));
 
@@ -423,12 +429,12 @@ TEST_CASE("tracker") {
     te.true_timestamp = &ts;
 
     t->track_timing(te);
-  
+
     expected[SNOWPLOW_UT_LABEL] = "hello world";
     auto new_payload = e.get_added_payloads()[1].get();
 
     REQUIRE(new_payload[SNOWPLOW_TRUE_TIMESTAMP] == to_string(ts));
-   
+
     SelfDescribingJson sde_w_label(SNOWPLOW_SCHEMA_USER_TIMINGS, expected);
     SelfDescribingJson uej_w_label(SNOWPLOW_SCHEMA_UNSTRUCT_EVENT, sde_w_label.get());
     string json_w_label = uej_w_label.to_string();
@@ -437,15 +443,21 @@ TEST_CASE("tracker") {
 
     Tracker::TimingEvent te1("", "", 123);
     bool arg_exception_on_no_category = false;
-    try { t->track_timing(te1); } 
-    catch (invalid_argument) { arg_exception_on_no_category = true; }
+    try {
+      t->track_timing(te1);
+    } catch (invalid_argument) {
+      arg_exception_on_no_category = true;
+    }
 
     REQUIRE(arg_exception_on_no_category == true);
 
     Tracker::TimingEvent te2("category", "", 123);
     bool arg_exception_on_no_variable = false;
-    try { t->track_timing(te2); } 
-    catch (invalid_argument) { arg_exception_on_no_variable = true; }
+    try {
+      t->track_timing(te2);
+    } catch (invalid_argument) {
+      arg_exception_on_no_variable = true;
+    }
 
     REQUIRE(arg_exception_on_no_variable == true);
 
@@ -478,7 +490,7 @@ TEST_CASE("tracker") {
     SelfDescribingJson uej(SNOWPLOW_SCHEMA_UNSTRUCT_EVENT, sdj.get());
 
     string json = uej.to_string();
-    const unsigned char* str = (const unsigned char*)json.c_str();
+    const unsigned char *str = (const unsigned char *)json.c_str();
 
     REQUIRE(payload[SNOWPLOW_UNSTRUCTURED_ENCODED] == base64_encode(str, json.length()));
 

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -16,6 +16,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "catch.hpp"
 #include "../src/utils.hpp"
 
+using namespace snowplow;
 using std::regex;
 using std::to_string;
 

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -11,10 +11,10 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
+#include "../src/utils.hpp"
+#include "catch.hpp"
 #include <algorithm>
 #include <regex>
-#include "catch.hpp"
-#include "../src/utils.hpp"
 
 using namespace snowplow;
 using std::regex;
@@ -40,7 +40,7 @@ TEST_CASE("utils") {
   }
 
   SECTION("int_list_to_string will successfully convert a list of integers to a string") {
-    list<int>* int_list = new list<int>;
+    list<int> *int_list = new list<int>;
     int_list->push_back(1);
     int_list->push_back(2);
     int_list->push_back(3);
@@ -50,11 +50,11 @@ TEST_CASE("utils") {
     REQUIRE("1,2,3,4,5" == Utils::int_list_to_string(int_list, ","));
 
     int_list->clear();
-    delete(int_list);
+    delete (int_list);
   }
 
   SECTION("map_to_query_string should correctly convert a map<string,string> to a query string") {
-    map<string,string> queryPairs;
+    map<string, string> queryPairs;
     queryPairs["e"] = "pv";
     queryPairs["k2"] = "s p a c e";
     queryPairs["k3"] = "s+p+a+c+e";
@@ -64,8 +64,8 @@ TEST_CASE("utils") {
 
   SECTION("url_encode should correctly encode a string for sending as part of a url") {
     REQUIRE("e%20pv" == Utils::url_encode("e pv"));
-    REQUIRE("%3C%20%3E%20%23%20%25%20%7B%20%7D%20%7C%20%5C%20%5E%20%7E%20%5B%20%5D%20%60%20%3B%20%2F%20%3F%20%3A%20%40%20%3D%20%26%20%24%20%2B%20%22" == 
-      Utils::url_encode("< > # % { } | \\ ^ ~ [ ] ` ; / ? : @ = & $ + \""));
+    REQUIRE("%3C%20%3E%20%23%20%25%20%7B%20%7D%20%7C%20%5C%20%5E%20%7E%20%5B%20%5D%20%60%20%3B%20%2F%20%3F%20%3A%20%40%20%3D%20%26%20%24%20%2B%20%22" ==
+            Utils::url_encode("< > # % { } | \\ ^ ~ [ ] ` ; / ? : @ = & $ + \""));
   }
 
   SECTION("serialize_payload will successfully convert a Payload into a JSON string") {
@@ -110,7 +110,7 @@ TEST_CASE("utils") {
 #elif defined(_WIN32)
     BOOL f64 = FALSE;
     is_64_bit_os = IsWow64Process(GetCurrentProcess(), &f64) && f64;
-#else 
+#else
     is_64_bit_os = false;
 #endif
     REQUIRE("Windows" == Utils::get_os_type());


### PR DESCRIPTION
This PR actually does 2 things:

1. Adds a C++ namespace `snowplow` to all classes and other types in the tracker.
2. Formats the code using the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
  * I like the idea of adopting an existing style guide that made some decisions and just making it consistent across the code base. It is based on the [Clang format style options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) and there are more style guides to choose from (e.g., Visual Studio, LLVM, Mozilla).
  * I appreciate that this is a bit out of scope from the task of adding a namespace. I wanted to adopt a formatting while adding the namespace and it turned out a bigger change :) I can separate this out into another PR if that makes sense.