### PR TITLE
Add support for Linux in desktop context, UUID generator, and CI (close #46, #47, and #50)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,18 @@ jobs:
 
     - name: Run tests
       run: .\x64\Debug\snowplow-cpp-tracker.exe
+
+  test-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install packages
+      run: sudo apt-get install -y libcurl4-openssl-dev uuid-dev
+
+    - name: Make
+      run: make
+
+    - name: Run tests
+      run: make unit-tests

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,16 @@ cxx-test-objects := $(patsubst %.cpp, %.o, $(cxx-test-files))
 cxx-example-objects := $(patsubst %.cpp, %.o, $(cxx-example-files))
 cxx-performance-objects := $(patsubst %.cpp, %.o, $(cxx-performance-files))
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S), Darwin)
 # Objective-C++ Files
 
 objcxx-src-files := $(shell find src -maxdepth 1 -name "*.mm")
 objcxx-objects := $(patsubst %.mm, %.o, $(objcxx-src-files))
+else
+objcxx-src-files :=
+objcxx-objects :=
+endif
 
 # Arguments
 
@@ -41,8 +47,13 @@ CXX := g++
 OBJCXX := c++
 CCFLAGS := -Werror -g
 CXXFLAGS := -std=c++11 -Werror -g -D SNOWPLOW_TEST_SUITE --coverage -O0
+ifeq ($(UNAME_S), Darwin)
 LDFLAGS := -framework CoreFoundation -framework CFNetwork -framework Foundation -framework CoreServices
 LDLIBS := -lcurl
+else
+LDLIBS := -lcurl -pthread -ldl -luuid
+LDFLAGS :=
+endif
 
 # Building
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@ Snowplow C++ tracker enables you to add analytics to your C++ applications, serv
 
 ## Quick Start
 
-The tracker currently supports macOS and Windows.
+The tracker supports macOS, Windows, and Linux.
 
 ### Installation
 
 Download the most recent release from the [releases section](https://github.com/snowplow/snowplow-cpp-tracker/releases). Everything in both the `src` and `include` folders will need to be included in your application. It is important to keep the same folder structure as references to the included headers have been done like so: `../include/json.hpp`.
+
+#### Requirements under Linux
+
+The following libraries need to be installed:
+
+* curl (using `apt install libcurl4-openssl-dev` on Ubuntu)
+* uuid (using `apt install uuid-dev` on Ubuntu)
 
 ### Using the tracker
 
@@ -62,7 +69,7 @@ Check the tracked events in a [Snowplow Micro](https://docs.snowplowanalytics.co
 
 ## Developer Quick Start
 
-### Building on macOS
+### Building on macOS and Linux
 
 ```bash
  host> git clone https://github.com/snowplow/snowplow-cpp-tracker
@@ -92,7 +99,7 @@ To run the test suite:
  host> make unit-tests
 ```
 
-If you wish to generate a local code coverage report you will first need to install [lcov](http://ltp.sourceforge.net/coverage/lcov.php) on your host machine.  The easiest way to do this is using [brew](http://brew.sh/):
+If you wish to generate a local code coverage report you will first need to install [lcov](http://ltp.sourceforge.net/coverage/lcov.php) on your host machine.  The easiest way to do this is using [brew](http://brew.sh/) under macOS:
 
 ```bash
  host> brew install lcov 

--- a/src/http/http_client_curl.cpp
+++ b/src/http/http_client_curl.cpp
@@ -14,12 +14,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #if !defined(WIN32) && !defined(_WIN32) && !defined(__WIN32) || defined(__CYGWIN__)
 #include "http_client_curl.hpp"
 #include "../constants.hpp"
-#include "curl/curl.h"
+#include <curl/curl.h>
 
 using namespace snowplow;
 using std::cerr;
 using std::endl;
-using std::lock_guard;
 
 HttpClientCurl::HttpClientCurl() {
   curl_global_init(CURL_GLOBAL_ALL);

--- a/src/http/http_client_curl.hpp
+++ b/src/http/http_client_curl.hpp
@@ -23,7 +23,6 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 using std::string;
 using std::list;
-using std::mutex;
 
 namespace snowplow {
 /**

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -215,30 +215,7 @@ int Utils::get_device_processor_count() {
   return sysinfo.dwNumberOfProcessors;
 }
 
-#elif defined(__APPLE__)
-
-string Utils::get_os_type() {
-  return "macOS";
-}
-
-string Utils::get_os_version() {
-  return get_os_version_objc();
-}
-
-string Utils::get_os_service_pack() {
-  return "";
-}
-
-string Utils::get_device_manufacturer() {
-  return "Apple Inc.";
-}
-
-string Utils::get_device_model() {
-  char str[256];
-  size_t size = sizeof(str);
-  int ret = sysctlbyname("hw.model", str, &size, NULL, 0);
-  return str;
-}
+#else
 
 bool Utils::get_os_is_64bit() {
 #if INTPTR_MAX == INT64_MAX
@@ -252,4 +229,54 @@ int Utils::get_device_processor_count() {
   return std::thread::hardware_concurrency();
 }
 
+string Utils::get_os_service_pack() {
+  return "";
+}
+
+#if defined(__APPLE__)
+
+string Utils::get_os_type() {
+  return "macOS";
+}
+
+string Utils::get_os_version() {
+  return get_os_version_objc();
+}
+
+string Utils::get_device_manufacturer() {
+  return "Apple Inc.";
+}
+
+string Utils::get_device_model() {
+  char str[256];
+  size_t size = sizeof(str);
+  int ret = sysctlbyname("hw.model", str, &size, NULL, 0);
+  return str;
+}
+
+#else
+
+#include <sys/utsname.h>
+
+string Utils::get_os_type() {
+  utsname info;
+  uname(&info);
+  return info.sysname; // e.g., Linux
+}
+
+string Utils::get_os_version() {
+  utsname info;
+  uname(&info);
+  return info.version; // e.g., #26~20.04.1-Ubuntu SMP Sat Jan 8 18:05:46 UTC 2022
+}
+
+string Utils::get_device_manufacturer() {
+  return "";
+}
+
+string Utils::get_device_model() {
+  return "";
+}
+
+#endif
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -59,6 +59,18 @@ string Utils::get_uuid4() {
   return uuid;
 }
 
+#else
+
+#include <uuid/uuid.h>
+
+string Utils::get_uuid4() {
+  uuid_t uuid;
+  char str[200];
+  uuid_generate_random(uuid);
+  uuid_unparse(uuid, str);
+  return string(str);
+}
+
 #endif
 
 string Utils::int_list_to_string(list<int> *int_list, const string &delimiter) {

--- a/test/storage_test.cpp
+++ b/test/storage_test.cpp
@@ -18,6 +18,7 @@ using namespace snowplow;
 using std::runtime_error;
 
 TEST_CASE("storage") {
+  Storage::close();
   Storage *storage = Storage::init("test1.db");
   REQUIRE("test1.db" == storage->get_db_name());
   storage->delete_all_event_rows();

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -91,8 +91,15 @@ TEST_CASE("utils") {
   }
 
   SECTION("get_device_context should populate OS specific information correctly") {
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+    string os_type = Utils::get_os_type();
+    string os_version = Utils::get_os_version();
+    string os_service_pack = Utils::get_os_service_pack();
+    bool os_is_64bit = Utils::get_os_is_64bit();
+    string device_manufacturer = Utils::get_device_manufacturer();
+    string device_model = Utils::get_device_model();
+    int device_processor_count = Utils::get_device_processor_count();
 
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
     DWORD expected_proc_count = std::thread::hardware_concurrency();
 
     OSVERSIONINFOEX osviex;
@@ -100,47 +107,53 @@ TEST_CASE("utils") {
     osviex.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
     REQUIRE(::GetVersionEx((LPOSVERSIONINFO)&osviex) != 0);
 
-    string os_version = to_string(osviex.dwMajorVersion) + "." + to_string(osviex.dwMinorVersion) + "." + to_string(osviex.dwBuildNumber);
-    string service_pack = to_string(osviex.wServicePackMajor) + "." + to_string(osviex.wServicePackMinor);
+    string expected_os_version = to_string(osviex.dwMajorVersion) + "." + to_string(osviex.dwMinorVersion) + "." + to_string(osviex.dwBuildNumber);
+    string expected_service_pack = to_string(osviex.wServicePackMajor) + "." + to_string(osviex.wServicePackMinor);
 
-    bool is_64_bit_os;
+    bool expected_is_64_bit_os;
 
 #if defined(_WIN64)
-    is_64_bit_os = true;
+    expected_is_64_bit_os = true;
 #elif defined(_WIN32)
     BOOL f64 = FALSE;
-    is_64_bit_os = IsWow64Process(GetCurrentProcess(), &f64) && f64;
+    expected_is_64_bit_os = IsWow64Process(GetCurrentProcess(), &f64) && f64;
 #else
-    is_64_bit_os = false;
+    expected_is_64_bit_os = false;
 #endif
-    REQUIRE("Windows" == Utils::get_os_type());
-    REQUIRE(os_version == Utils::get_os_version());
-    REQUIRE(service_pack == Utils::get_os_service_pack());
-    REQUIRE(is_64_bit_os == Utils::get_os_is_64bit());
-    REQUIRE("" == Utils::get_device_manufacturer());
-    REQUIRE("" == Utils::get_device_model());
-    REQUIRE(expected_proc_count == Utils::get_device_processor_count());
+    REQUIRE("Windows" == os_type);
+    REQUIRE(expected_os_version == os_version);
+    REQUIRE(expected_service_pack == os_service_pack);
+    REQUIRE(expected_is_64_bit_os == os_is_64bit);
+    REQUIRE("" == device_manufacturer);
+    REQUIRE("" == device_model);
+    REQUIRE(expected_proc_count == device_processor_count);
 #elif defined(__APPLE__)
-    REQUIRE("macOS" == Utils::get_os_type());
-    REQUIRE("" != Utils::get_os_version());
-    REQUIRE("" == Utils::get_os_service_pack());
-    REQUIRE((true || false) == Utils::get_os_is_64bit());
-    REQUIRE("Apple Inc." == Utils::get_device_manufacturer());
-    REQUIRE("" != Utils::get_device_model());
-    REQUIRE(0 != Utils::get_device_processor_count());
+    REQUIRE("macOS" == os_type);
+    REQUIRE("" != os_version);
+    REQUIRE("" == os_service_pack);
+    REQUIRE("Apple Inc." == device_manufacturer);
+    REQUIRE("" != device_model);
+    REQUIRE(0 != device_processor_count);
+#else
+    REQUIRE("Linux" == os_type);
+    REQUIRE("" != os_version);
+    REQUIRE("" == os_service_pack);
+    REQUIRE("" == device_manufacturer);
+    REQUIRE("" == device_model);
+    REQUIRE(0 != device_processor_count);
+#endif
 
     SelfDescribingJson desktop_context = Utils::get_desktop_context();
     json desktop_context_json = desktop_context.get();
     json desktop_context_data = desktop_context_json[SNOWPLOW_DATA];
 
     REQUIRE(SNOWPLOW_SCHEMA_DESKTOP_CONTEXT == desktop_context_json[SNOWPLOW_SCHEMA].get<std::string>());
-    REQUIRE("macOS" == desktop_context_data[SNOWPLOW_DESKTOP_OS_TYPE].get<std::string>());
-    REQUIRE("" != desktop_context_data[SNOWPLOW_DESKTOP_OS_VERSION].get<std::string>());
-    REQUIRE("" == desktop_context_data[SNOWPLOW_DESKTOP_OS_SERVICE_PACK].get<std::string>());
-    REQUIRE((true || false) == desktop_context_data[SNOWPLOW_DESKTOP_OS_IS_64_BIT].get<bool>());
-    REQUIRE("Apple Inc." == desktop_context_data[SNOWPLOW_DESKTOP_DEVICE_MANU].get<std::string>());
-    REQUIRE("" != desktop_context_data[SNOWPLOW_DESKTOP_DEVICE_MODEL].get<std::string>());
-    REQUIRE(0 != desktop_context_data[SNOWPLOW_DESKTOP_DEVICE_PROC_COUNT].get<int>());
-#endif
+    REQUIRE(os_type == desktop_context_data[SNOWPLOW_DESKTOP_OS_TYPE].get<std::string>());
+    REQUIRE(os_version == desktop_context_data[SNOWPLOW_DESKTOP_OS_VERSION].get<std::string>());
+    REQUIRE(os_service_pack == desktop_context_data[SNOWPLOW_DESKTOP_OS_SERVICE_PACK].get<std::string>());
+    REQUIRE(os_is_64bit == desktop_context_data[SNOWPLOW_DESKTOP_OS_IS_64_BIT].get<bool>());
+    REQUIRE(device_manufacturer == desktop_context_data[SNOWPLOW_DESKTOP_DEVICE_MANU].get<std::string>());
+    REQUIRE(device_model == desktop_context_data[SNOWPLOW_DESKTOP_DEVICE_MODEL].get<std::string>());
+    REQUIRE(device_processor_count == desktop_context_data[SNOWPLOW_DESKTOP_DEVICE_PROC_COUNT].get<int>());
   }
 }


### PR DESCRIPTION
This PR adds support for Linux in the remaining places where it was lacking:

* #46 
* #47 
* #50 

## Desktop context

In desktop context, I wasn't able to fill in all the information. I ended going with this:

* `osType` is set using sysname property from `sys/utsname`, which ends up being Linux.
* `osVersion` is set using version property from `sys/utsname`, which ends being something like `#26~20.04.1-Ubuntu SMP Sat Jan 8 18:05:46 UTC 2022`. This is different from Windows and macOS which use the standard "major.minor.patch" versioning. But I think that the Linux ecosystem is more complex and this is the most useful version representation that I could find. The date of the release is a bit useless, not sure if I should edit the version string. I can apply some regex if we want to extract only a part of it.
* `osServicePack` is empty string (it's also empty on macOS)
* `osIs64Bit` works as expected
* `deviceManufacturer` is empty string – couldn't find any such information, only very partial ones. Linux machines are heterogeneous.
* `deviceModel` is also empty.
* `deviceProcessorCount` works as expected.

## Docs

I updated instructions in the README. Also looked at the docs, but the only place I found that required changes was the list of supported platforms – [here is a PR](https://github.com/snowplow-incubator/data-value-resources/pull/81).