### PR TITLE
Add a header file that includes all the published APIs (close #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ The following libraries need to be installed:
 
 ### Using the tracker
 
-Import and initialize the tracker with your Snowplow collector endpoint and tracker configuration:
+Import using the `snowplow.hpp` header file and initialize the tracker with your Snowplow collector endpoint and tracker configuration:
 
 ```cpp
-#include "tracker.hpp"
+#include "snowplow.hpp"
 
 using namespace snowplow;
 

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -2,10 +2,7 @@
 #include <string>
 #include <time.h>
 
-#include "../src/tracker.hpp"
-#include "../src/events/structured_event.hpp"
-#include "../src/events/timing_event.hpp"
-#include "../src/events/screen_view_event.hpp"
+#include "../src/snowplow.hpp"
 
 using snowplow::ClientSession;
 using snowplow::Emitter;

--- a/performance/main.cpp
+++ b/performance/main.cpp
@@ -14,8 +14,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include <fstream>
 #include <string>
 
-#include "../src/storage.hpp"
-#include "../src/utils.hpp"
+#include "../src/snowplow.hpp"
 #include "run.hpp"
 
 using snowplow::SelfDescribingJson;

--- a/performance/mock_client_session.hpp
+++ b/performance/mock_client_session.hpp
@@ -14,7 +14,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #ifndef MOCK_CLIENT_SESSION_H
 #define MOCK_CLIENT_SESSION_H
 
-#include "../src/client_session.hpp"
+#include "../src/snowplow.hpp"
 
 using snowplow::ClientSession;
 using snowplow::SelfDescribingJson;

--- a/performance/mock_emitter.hpp
+++ b/performance/mock_emitter.hpp
@@ -14,7 +14,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #ifndef MOCK_EMITTER_H
 #define MOCK_EMITTER_H
 
-#include "../src/emitter.hpp"
+#include "../src/snowplow.hpp"
 
 using snowplow::Emitter;
 using snowplow::Payload;

--- a/performance/mute_emitter.hpp
+++ b/performance/mute_emitter.hpp
@@ -14,7 +14,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #ifndef MUTE_EMITTER_H
 #define MUTE_EMITTER_H
 
-#include "../src/emitter.hpp"
+#include "../src/snowplow.hpp"
 
 using snowplow::Emitter;
 using std::string;

--- a/performance/run.cpp
+++ b/performance/run.cpp
@@ -14,11 +14,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include <chrono>
 #include <string>
 
-#include "../src/subject.hpp"
-#include "../src/tracker.hpp"
-#include "../src/events/structured_event.hpp"
-#include "../src/events/timing_event.hpp"
-#include "../src/events/screen_view_event.hpp"
+#include "../src/snowplow.hpp"
 #include "mock_client_session.hpp"
 #include "mock_emitter.hpp"
 #include "mute_emitter.hpp"

--- a/src/snowplow.hpp
+++ b/src/snowplow.hpp
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+
+This program is licensed to you under the Apache License Version 2.0,
+and you may not use this file except in compliance with the Apache License Version 2.0.
+You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the Apache License Version 2.0 is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+*/
+
+#ifndef SNOWPLOW_H
+#define SNOWPLOW_H
+
+/**
+ * @brief This file provides the single header to import when using the Snowplow tracker in your code.
+ */
+
+#include "client_session.hpp"
+#include "emitter.hpp"
+#include "storage.hpp"
+#include "subject.hpp"
+#include "tracker.hpp"
+
+// http
+#include "http/http_client.hpp"
+#include "http/http_client_apple.hpp"
+#include "http/http_client_curl.hpp"
+#include "http/http_client_windows.hpp"
+
+// payload
+#include "payload/self_describing_json.hpp"
+
+// events
+#include "events/event.hpp"
+#include "events/screen_view_event.hpp"
+#include "events/self_describing_event.hpp"
+#include "events/structured_event.hpp"
+#include "events/timing_event.hpp"
+
+#endif


### PR DESCRIPTION
Add a `snowplow.hpp` header file to make it easier to import the library in users apps – instead of importing each Snowplow class individually, this imports all the published classes. Also gives us more freedom to move stuff around.