### PR TITLE
Add customizable no-retry HTTP status codes (close #54)

### DIFF
--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -15,8 +15,10 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #define CONSTANTS_H
 
 #include <string>
+#include <set>
 
 using std::string;
+using std::set;
 
 namespace snowplow {
 const string SNOWPLOW_TRACKER_VERSION_LABEL = "cpp-0.2.0";
@@ -58,6 +60,7 @@ const string SNOWPLOW_TRACKER_VERSION = "tv";
 const string SNOWPLOW_APP_ID = "aid";
 const string SNOWPLOW_SP_NAMESPACE = "tna";
 const string SNOWPLOW_PLATFORM = "p";
+const set<int> SNOWPLOW_FAIL_NO_RETRY_HTTP_STATUS_CODES = {400, 401, 403, 410, 422};
 
 // subject class
 const string SNOWPLOW_UID = "uid";

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -197,6 +197,17 @@ public:
    */
   void set_request_callback(const EmitterCallback &callback, EmitStatus emit_status);
 
+  /**
+   * @brief Set a custom retry rule for when the HTTP status code is received in emit response from Collector.
+   * 
+   * This overrides default behavior for HTTP status codes greater than 300.
+   * The custom retry rules can't be changed when the Emitter is running.
+   * 
+   * @param http_status_code HTTP status code
+   * @param retry Whether events should be retried or not
+   */
+  void set_custom_retry_for_status_code(int http_status_code, bool retry);
+
 private:
   CrackedUrl m_url;
   Method m_method;
@@ -214,6 +225,7 @@ private:
   bool m_running;
   EmitterCallback m_callback;
   EmitStatus m_callback_emit_status;
+  map<int, bool> m_custom_retry_for_status_codes;
 
   void run();
   void do_send(const list<Storage::EventRow> &event_rows, list<HttpRequestResult> *results);

--- a/src/http/http_request_result.hpp
+++ b/src/http/http_request_result.hpp
@@ -32,7 +32,7 @@ public:
   int get_http_response_code() const;
   list<int> get_row_ids() const;
   bool is_success() const;
-  bool should_retry() const;
+  bool should_retry(const map<int, bool> &custom_retry_for_status_codes) const;
 
 private:
   bool is_internal_error() const;


### PR DESCRIPTION
Addresses issue #54 and disables retries for selected HTTP status codes (400, 401, 403, 410, and 422). It also adds an option to override this behavior and set custom retry rules for given status codes. The emitter callback can be used to get feedback in case events are dropped.

## Documentation: HTTP request retry behavior

The Emitter has a retry functionality that repeatedly sends the same events to the Collector in case HTTP requests fail to get through. Requests are retried in case the connection to the Collector fails to be estabilished. They are also retried for all 3xx and 5xx HTTP status codes in server response and most 4xx status codes with the following exceptions – 400, 401, 403, 410, and 422. These status codes signal a rejection of the events being sent to the Collector and, therefore, the events in the requests are dropped and not sent again.

The Emitter provides an option to set custom retry behavior for 3xx, 4xx and 5xx HTTP status codes. You can call the `set_retry_for_status_code` function on the Emitter instance to define whether to retry or not for a given HTTP status code. Here is an example that overrides the default behavior and enables retries on 422 status code:

```cpp
emitter.set_retry_for_status_code(422, true);
```

---

There is also a [PR on data-value-resources](https://github.com/snowplow-incubator/data-value-resources/pull/85) with the documentation updates.