### PR TITLE
Add back-off on 100% event sending failure (close #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This will create two executables - the first is the test-suite which can be exec
 The other is an example program which will send one of every type of event to an endpoint of your choosing like so:
 
 ```bash
- host> cd build
+ host> cd build/example
  host> ./tracker_example {{ your collector uri }}
 ```
 

--- a/snowplow-cpp-tracker-example.vcxproj
+++ b/snowplow-cpp-tracker-example.vcxproj
@@ -102,7 +102,8 @@
     <ClCompile Include="include\sqlite3.c" />
     <ClCompile Include="src\client_session.cpp" />
     <ClCompile Include="src\cracked_url.cpp" />
-    <ClCompile Include="src\emitter.cpp" />
+    <ClCompile Include="src\emitter\emitter.cpp" />
+    <ClCompile Include="src\emitter\retry_delay.cpp" />
     <ClCompile Include="src\http\http_client_windows.cpp" />
     <ClCompile Include="src\http\http_request_result.cpp" />
     <ClCompile Include="src\payload\payload.cpp" />
@@ -125,7 +126,8 @@
     <ClInclude Include="src\client_session.hpp" />
     <ClInclude Include="src\constants.hpp" />
     <ClInclude Include="src\cracked_url.hpp" />
-    <ClInclude Include="src\emitter.hpp" />
+    <ClInclude Include="src\emitter\emitter.hpp" />
+    <ClInclude Include="src\emitter\retry_delay.hpp" />
     <ClInclude Include="src\http\http_client.hpp" />
     <ClInclude Include="src\http\http_client_windows.hpp" />
     <ClInclude Include="src\http\http_request_result.hpp" />

--- a/snowplow-cpp-tracker-example.vcxproj.filters
+++ b/snowplow-cpp-tracker-example.vcxproj.filters
@@ -21,7 +21,10 @@
     <ClCompile Include="src\cracked_url.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="src\emitter.cpp">
+    <ClCompile Include="src\emitter\emitter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\emitter\retry_delay.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\http\http_client_windows.cpp">
@@ -86,7 +89,10 @@
     <ClInclude Include="src\cracked_url.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="src\emitter.hpp">
+    <ClInclude Include="src\emitter\emitter.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\emitter\retry_delay.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\http\http_client.hpp">

--- a/snowplow-cpp-tracker.vcxproj
+++ b/snowplow-cpp-tracker.vcxproj
@@ -106,7 +106,8 @@
     <ClCompile Include="include\sqlite3.c" />
     <ClCompile Include="src\client_session.cpp" />
     <ClCompile Include="src\cracked_url.cpp" />
-    <ClCompile Include="src\emitter.cpp" />
+    <ClCompile Include="src\emitter\emitter.cpp" />
+    <ClCompile Include="src\emitter\retry_delay.cpp" />
     <ClCompile Include="src\http\http_client_windows.cpp" />
     <ClCompile Include="src\http\http_request_result.cpp" />
     <ClCompile Include="src\payload\payload.cpp" />
@@ -124,7 +125,8 @@
     <ClCompile Include="test\http\test_http_client.cpp" />
     <ClCompile Include="test\client_session_test.cpp" />
     <ClCompile Include="test\cracked_url_test.cpp" />
-    <ClCompile Include="test\emitter_test.cpp" />
+    <ClCompile Include="test\emitter\emitter_test.cpp" />
+    <ClCompile Include="test\emitter\retry_delay_test.cpp" />
     <ClCompile Include="test\http\http_client_test.cpp" />
     <ClCompile Include="test\http\http_request_result_test.cpp" />
     <ClCompile Include="test\main.cpp" />
@@ -143,7 +145,8 @@
     <ClInclude Include="src\client_session.hpp" />
     <ClInclude Include="src\constants.hpp" />
     <ClInclude Include="src\cracked_url.hpp" />
-    <ClInclude Include="src\emitter.hpp" />
+    <ClInclude Include="src\emitter\emitter.hpp" />
+    <ClInclude Include="src\emitter\retry_delay.hpp" />
     <ClInclude Include="src\http\http_client.hpp" />
     <ClInclude Include="src\http\http_client_windows.hpp" />
     <ClInclude Include="src\http\http_request_result.hpp" />

--- a/snowplow-cpp-tracker.vcxproj.filters
+++ b/snowplow-cpp-tracker.vcxproj.filters
@@ -21,7 +21,10 @@
     <ClCompile Include="src\cracked_url.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="src\emitter.cpp">
+    <ClCompile Include="src\emitter\emitter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\emitter\retry_delay.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\http\http_client_windows.cpp">
@@ -81,7 +84,10 @@
     <ClCompile Include="test\cracked_url_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="test\emitter_test.cpp">
+    <ClCompile Include="test\emitter\emitter_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test\emitter\retry_delay_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="test\http\http_client_test.cpp">
@@ -125,7 +131,10 @@
     <ClInclude Include="src\cracked_url.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="src\emitter.hpp">
+    <ClInclude Include="src\emitter\emitter.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\emitter\retry_delay.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\http\http_client.hpp">

--- a/src/emitter/emitter.hpp
+++ b/src/emitter/emitter.hpp
@@ -20,14 +20,15 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include <future>
 #include <thread>
 #include <algorithm>
-#include "constants.hpp"
-#include "utils.hpp"
-#include "storage/event_store.hpp"
-#include "payload/payload.hpp"
-#include "payload/self_describing_json.hpp"
-#include "cracked_url.hpp"
-#include "http/http_request_result.hpp"
-#include "http/http_client.hpp"
+#include "../constants.hpp"
+#include "../utils.hpp"
+#include "../storage/event_store.hpp"
+#include "../payload/payload.hpp"
+#include "../payload/self_describing_json.hpp"
+#include "../cracked_url.hpp"
+#include "../http/http_request_result.hpp"
+#include "../http/http_client.hpp"
+#include "retry_delay.hpp"
 
 using std::string;
 using std::thread;
@@ -222,6 +223,7 @@ private:
   EmitterCallback m_callback;
   EmitStatus m_callback_emit_status;
   map<int, bool> m_custom_retry_for_status_codes;
+  RetryDelay m_retry_delay;
 
   void run();
   void do_send(const list<EventRow> &event_rows, list<HttpRequestResult> *results);

--- a/src/emitter/retry_delay.cpp
+++ b/src/emitter/retry_delay.cpp
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+
+This program is licensed to you under the Apache License Version 2.0,
+and you may not use this file except in compliance with the Apache License Version 2.0.
+You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the Apache License Version 2.0 is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+*/
+
+#include "retry_delay.hpp"
+#include <random>
+
+using namespace snowplow;
+using std::min;
+
+RetryDelay::RetryDelay(double base, double factor, int retry_count_cap, double jitter) {
+  m_base = base;
+  m_factor = factor;
+  m_retry_count_cap = retry_count_cap;
+  m_jitter = jitter;
+  m_retry_count = 0;
+}
+
+void RetryDelay::will_retry_emit() {
+  m_retry_count++;
+}
+
+void RetryDelay::wont_retry_emit() {
+  m_retry_count = 0;
+}
+
+milliseconds RetryDelay::get() const {
+  if (m_retry_count == 0) {
+    return milliseconds(0);
+  }
+
+  double delay_ms = m_base * pow(m_factor, min(m_retry_count, m_retry_count_cap) - 1);
+
+  if (m_jitter != 0) {
+    std::random_device rd;
+    std::mt19937 mt(rd());
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    double seed = dist(mt);
+    double deviation = floor(seed * m_jitter * delay_ms);
+
+    if (round(seed) == 1) {
+      delay_ms -= deviation;
+    } else {
+      delay_ms += deviation;
+    }
+  }
+
+  return milliseconds((unsigned long) delay_ms);
+}

--- a/src/emitter/retry_delay.hpp
+++ b/src/emitter/retry_delay.hpp
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+
+This program is licensed to you under the Apache License Version 2.0,
+and you may not use this file except in compliance with the Apache License Version 2.0.
+You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the Apache License Version 2.0 is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+*/
+
+#ifndef RETRY_DELAY_H
+#define RETRY_DELAY_H
+
+#include <chrono>
+
+using std::chrono::milliseconds;
+
+namespace snowplow {
+/**
+ * @brief Calculates exponential retry delay for Emitter based on the number of retry attempts.
+ */
+class RetryDelay {
+public:
+  /**
+   * @brief Construct a new RetryDely object
+   *
+   * @param base Base delay in milliseconds
+   * @param factor Multiplicative factor for exponential function
+   * @param retry_count_cap Maximum retry count to consider in the retry delay calculation
+   * @param jitter Amount of randomness to introduce in the calculation (from 0 to 1)
+   */
+  RetryDelay(double base = 100.0, double factor = 2.0, int retry_count_cap = 10, double jitter = 0.1);
+
+  /**
+   * @brief Update retry delay considering that a new retry is planned.
+   */
+  void will_retry_emit();
+
+  /**
+   * @brief Update retry delay considering that no more retries are planned.
+   */
+  void wont_retry_emit();
+
+  milliseconds get() const;
+
+private:
+  int m_retry_count;
+  double m_base;
+  double m_factor;
+  int m_retry_count_cap;
+  double m_jitter;
+};
+} // namespace snowplow
+
+#endif

--- a/src/snowplow.hpp
+++ b/src/snowplow.hpp
@@ -19,9 +19,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
  */
 
 #include "client_session.hpp"
-#include "emitter.hpp"
 #include "subject.hpp"
 #include "tracker.hpp"
+
+// emitter
+#include "emitter/emitter.hpp"
 
 // storage
 #include "storage/event_row.hpp"

--- a/src/tracker.hpp
+++ b/src/tracker.hpp
@@ -15,7 +15,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #define TRACKER_H
 
 #include <string>
-#include "emitter.hpp"
+#include "emitter/emitter.hpp"
 #include "subject.hpp"
 #include "client_session.hpp"
 #include "events/event.hpp"

--- a/test/emitter/emitter_test.cpp
+++ b/test/emitter/emitter_test.cpp
@@ -11,12 +11,12 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "../src/emitter.hpp"
-#include "../src/payload/event_payload.hpp"
-#include "http/test_http_client.hpp"
-#include "../src/storage/sqlite_storage.hpp"
-#include "catch.hpp"
-#include "http/test_http_client.hpp"
+#include "../../src/emitter/emitter.hpp"
+#include "../../src/payload/event_payload.hpp"
+#include "../http/test_http_client.hpp"
+#include "../../src/storage/sqlite_storage.hpp"
+#include "../catch.hpp"
+#include "../http/test_http_client.hpp"
 
 using namespace snowplow;
 using std::invalid_argument;
@@ -333,6 +333,21 @@ TEST_CASE("emitter") {
     TestHttpClient::set_temporary_response_code(422); // retry
     track_sample_event(emitter);
     REQUIRE(2 == TestHttpClient::get_requests_list().size());
+    TestHttpClient::reset();
+
+    emitter.stop();
+  }
+
+  SECTION("Emitter sleeps in between retries") {
+    Emitter emitter("com.acme.collector", Emitter::Method::POST, Emitter::Protocol::HTTP, 500, 500, 500, storage, unique_ptr<HttpClient>(new TestHttpClient()));
+
+    TestHttpClient::set_temporary_response_code(501, 5); // retry with 5 failures
+    auto t_start = std::chrono::high_resolution_clock::now();
+    track_sample_event(emitter);
+    auto t_end = std::chrono::high_resolution_clock::now();
+    double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
+    REQUIRE(6 == TestHttpClient::get_requests_list().size());
+    REQUIRE(1000 < elapsed_time_ms);
     TestHttpClient::reset();
 
     emitter.stop();

--- a/test/emitter/retry_delay_test.cpp
+++ b/test/emitter/retry_delay_test.cpp
@@ -1,0 +1,64 @@
+/*
+Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+
+This program is licensed to you under the Apache License Version 2.0,
+and you may not use this file except in compliance with the Apache License Version 2.0.
+You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the Apache License Version 2.0 is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+*/
+
+#include "../../src/emitter/retry_delay.hpp"
+#include "../catch.hpp"
+#include "../http/test_http_client.hpp"
+
+using namespace snowplow;
+using std::chrono::milliseconds;
+
+TEST_CASE("RetryDelay") {
+  SECTION("retry delay is increasing as expected") {
+    RetryDelay retry_delay(100, 2, 10, 0);
+    REQUIRE(milliseconds(0) == retry_delay.get());
+    retry_delay.will_retry_emit();
+    REQUIRE(milliseconds(100) == retry_delay.get());
+    retry_delay.will_retry_emit();
+    REQUIRE(milliseconds(200) == retry_delay.get());
+    retry_delay.will_retry_emit();
+    REQUIRE(milliseconds(400) == retry_delay.get());
+    retry_delay.will_retry_emit();
+    REQUIRE(milliseconds(800) == retry_delay.get());
+  }
+
+  SECTION("retry delay stops increasing when retry count cap is reached") {
+    RetryDelay retry_delay(100, 2, 1, 0);
+    retry_delay.will_retry_emit();
+    REQUIRE(milliseconds(100) == retry_delay.get());
+    retry_delay.will_retry_emit();
+    REQUIRE(milliseconds(100) == retry_delay.get());
+  }
+
+  SECTION("retry delay adds randomness") {
+    RetryDelay retry_delay(100, 2, 11, 0.1);
+    for (int i = 0; i < 11; i++) {
+      retry_delay.will_retry_emit();
+    }
+    REQUIRE(retry_delay.get() != retry_delay.get());
+    int expected = 102400;
+    REQUIRE(milliseconds(expected - expected / 10).count() < retry_delay.get().count());
+    REQUIRE(milliseconds(expected + expected / 10).count() > retry_delay.get().count());
+  }
+
+  SECTION("retry delay resets if won't retry") {
+    RetryDelay retry_delay(100, 2, 10, 0);
+    auto delay0 = retry_delay.get();
+    retry_delay.will_retry_emit();
+    auto delay1 = retry_delay.get();
+    retry_delay.wont_retry_emit();
+    auto delay2 = retry_delay.get();
+    REQUIRE(delay1 > delay2);
+    REQUIRE(delay0 == delay2);
+  }
+}

--- a/test/http/test_http_client.cpp
+++ b/test/http/test_http_client.cpp
@@ -24,6 +24,7 @@ list<TestHttpClient::Request> TestHttpClient::requests_list;
 mutex TestHttpClient::log_read_write;
 int TestHttpClient::response_code = 200;
 int TestHttpClient::temporary_response_code = -1;
+int TestHttpClient::temporary_response_code_remaining_attempts = 0;
 
 HttpRequestResult TestHttpClient::http_request(const RequestMethod method, CrackedUrl url, const string &query_string, const string &post_data, list<int> row_ids, bool oversize) {
   lock_guard<mutex> guard(log_read_write);
@@ -44,15 +45,16 @@ void TestHttpClient::set_http_response_code(int http_response_code) {
   response_code = http_response_code;
 }
 
-void TestHttpClient::set_temporary_response_code(int http_response_code) {
+void TestHttpClient::set_temporary_response_code(int http_response_code, int number_of_attempts) {
   lock_guard<mutex> guard(log_read_write);
   temporary_response_code = http_response_code;
+  temporary_response_code_remaining_attempts = number_of_attempts;
 }
 
 int TestHttpClient::fetch_response_code() {
-  if (temporary_response_code >= 0) {
+  if (temporary_response_code_remaining_attempts > 0) {
     int code = temporary_response_code;
-    temporary_response_code = -1;
+    temporary_response_code_remaining_attempts--;
     return code;
   }
   return response_code;

--- a/test/http/test_http_client.hpp
+++ b/test/http/test_http_client.hpp
@@ -44,10 +44,11 @@ public:
   static list<Request> requests_list;
   static int response_code;
   static int temporary_response_code;
+  static int temporary_response_code_remaining_attempts;
   static mutex log_read_write;
 
   static void set_http_response_code(int http_response_code);
-  static void set_temporary_response_code(int http_response_code);
+  static void set_temporary_response_code(int http_response_code, int number_of_attempts = 1);
   static list<Request> get_requests_list();
   static void reset();
 

--- a/test/tracker_test.cpp
+++ b/test/tracker_test.cpp
@@ -13,7 +13,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "../include/base64.hpp"
 #include "../include/json.hpp"
-#include "../src/emitter.hpp"
+#include "../src/emitter/emitter.hpp"
 #include "../src/tracker.hpp"
 #include "../src/events/structured_event.hpp"
 #include "../src/events/screen_view_event.hpp"


### PR DESCRIPTION
This PR addresses issue #9 and adds an exponential retry delay to the emitter. The implementation is based on the [proposal here](https://github.com/snowplow-incubator/data-value-resources/pull/91).

Since there is a single daemon thread in the emitter that is responsible for sending requests, I added a "sleep" in between failed requests. The retry delay calculation is encapsulated in the internal `RetryDelay`class. It has the following properties:

1. is an exponential function starting at 100ms and doubling each time,
2. adds a bit of randomness (up to 10%) to the retry delay,
3. is capped to consider at most 10 retries (doesn't increase the delay after that) – in practice it means that the delay can be at most around 2 minutes.

## Docs update: Request retry delay (back-off)

Failed requests are retried with exponentially increasing delays between subsequent retry requests. This ensures that the Collector is not overwhelmed with too many requests and also saves resources on the client by reducing the number of requests during failures.

The retry delay calculation is an exponential function with multiplicative factor 2. To prevent spikes of traffic, small amount of randomness is added to the delay (at most 10% of the total value). Finally, it is limited to be no larger than around 2 minutes. The following is a sample sequence of the retry delays given 5 failed requests: 0.101s, 0.198s, 0.404s, 0.791s, 1.603s.

[Here is a PR for docs](https://github.com/snowplow-incubator/data-value-resources/pull/93) on data-value-resources.