### PR TITLE
Add IP address property to Subject (close #62)

### DIFF
--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -70,6 +70,7 @@ const string SNOWPLOW_COLOR_DEPTH = "cd";
 const string SNOWPLOW_TIMEZONE = "tz";
 const string SNOWPLOW_LANGUAGE = "lang";
 const string SNOWPLOW_USERAGENT = "ua";
+const string SNOWPLOW_IP_ADDRESS = "ip";
 
 // structured event
 const string SNOWPLOW_SE_CATEGORY = "se_ca";

--- a/src/subject.cpp
+++ b/src/subject.cpp
@@ -45,6 +45,10 @@ void Subject::set_useragent(const string &useragent) {
   this->m_payload.add(SNOWPLOW_USERAGENT, useragent);
 }
 
+void Subject::set_ip_address(const string &ip_address) {
+  this->m_payload.add(SNOWPLOW_IP_ADDRESS, ip_address);
+}
+
 map<string, string> Subject::get_map() {
   return this->m_payload.get();
 }

--- a/src/subject.hpp
+++ b/src/subject.hpp
@@ -14,10 +14,10 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #ifndef SUBJECT_H
 #define SUBJECT_H
 
+#include "constants.hpp"
+#include "payload/payload.hpp"
 #include <map>
 #include <string>
-#include "payload/payload.hpp"
-#include "constants.hpp"
 
 using std::map;
 using std::string;
@@ -33,14 +33,14 @@ private:
 public:
   /**
    * @brief Set the business user ID string
-   * 
+   *
    * @param user_id Business user ID
    */
-  void set_user_id(const string & user_id);
+  void set_user_id(const string &user_id);
 
   /**
    * @brief Set the device screen resolution
-   * 
+   *
    * @param width Device screen resolution width
    * @param height Device screen resolution height
    */
@@ -48,7 +48,7 @@ public:
 
   /**
    * @brief Set the device viewport dimensions
-   * 
+   *
    * @param width Device viewport width
    * @param height Device viewport height
    */
@@ -56,39 +56,46 @@ public:
 
   /**
    * @brief Set the bit depth of the device’s color palette for displaying images
-   * 
+   *
    * @param depth Device color depth
    */
   void set_color_depth(int depth);
 
   /**
    * @brief Set the user’s timezone.
-   * 
+   *
    * @param timezone User's timezone (e.g., "Europe/London")
    */
-  void set_timezone(const string & timezone);
+  void set_timezone(const string &timezone);
 
   /**
    * @brief Set the user's language
-   * 
+   *
    * @param language User's language (e.g., "en")
    */
-  void set_language(const string & language);
+  void set_language(const string &language);
 
   /**
    * @brief Set the useragent string for the event
-   * 
+   *
    * @param user_agent Standard formatted useragent string (e.g., "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4)...")
    */
-  void set_useragent(const string & user_agent);
+  void set_useragent(const string &user_agent);
+
+  /**
+   * @brief Set the user's IP address
+   *
+   * @param user_agent IP address as string
+   */
+  void set_ip_address(const string &ip_address);
 
   /**
    * @brief Get the subject properties as a map of strings
-   * 
+   *
    * @return map<string, string> Subject properties to be added to events
    */
   map<string, string> get_map();
 };
-}
+} // namespace snowplow
 
 #endif

--- a/test/subject_test.cpp
+++ b/test/subject_test.cpp
@@ -55,4 +55,9 @@ TEST_CASE("subject") {
     sub.set_useragent(useragent);
     REQUIRE(sub.get_map()["ua"] == useragent);
   }
+
+  SECTION("set_ip_address adds a value for key ip") {
+    sub.set_ip_address("192.168.0.1");
+    REQUIRE(sub.get_map()["ip"] == "192.168.0.1");
+  }
 }


### PR DESCRIPTION
Issue #62 

Adds a `set_ip_address` function to the Subject which was missing before but is provided in other trackers (e.g., the Java tracker).

Originally, I also wanted to add properties for domain user id, network user id and session id but these are mostly useful for page views and web events and the C++ tracker doesn't even provide such events out of the box. That's why I decided to skip those (even though the Java tracker provides them).