### PR TITLE
Add event-level Subject (close #61)

### DIFF
--- a/src/events/event.cpp
+++ b/src/events/event.cpp
@@ -17,6 +17,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 using namespace snowplow;
 using std::to_string;
 using std::invalid_argument;
+using std::move;
 
 Event::Event() {
   this->m_true_timestamp = NULL;
@@ -57,6 +58,10 @@ unsigned long long *Event::get_true_timestamp() const {
   return m_true_timestamp;
 }
 
+shared_ptr<Subject> Event::get_subject() const {
+  return m_subject;
+}
+
 // --- Setters
 
 void Event::set_true_timestamp(unsigned long long *true_timestamp) {
@@ -65,4 +70,8 @@ void Event::set_true_timestamp(unsigned long long *true_timestamp) {
 
 void Event::set_context(const vector<SelfDescribingJson> &context) {
   m_context = context;
+}
+
+void Event::set_subject(shared_ptr<Subject> subject) {
+  m_subject = move(subject);
 }

--- a/src/events/event.hpp
+++ b/src/events/event.hpp
@@ -16,11 +16,13 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "../payload/self_describing_json.hpp"
 #include "../payload/event_payload.hpp"
+#include "../subject.hpp"
 #include <string>
 #include <vector>
 
 using std::string;
 using std::vector;
+using std::shared_ptr;
 
 namespace snowplow {
 /**
@@ -61,6 +63,13 @@ public:
    */
   void set_true_timestamp(unsigned long long *true_timestamp);
 
+  /**
+   * @brief Set the optional subject object to supply additional information to the event.
+   * 
+   * @param subject Shared pointer to Subject instance
+   */
+  void set_subject(shared_ptr<Subject> subject);
+
 protected:
   /**
    * @brief This function is overriden by concrete event classes and returns payload with properties for the event types.
@@ -80,9 +89,12 @@ protected:
   EventPayload get_self_describing_event_payload(const SelfDescribingJson &event, bool use_base64) const;
 
 private:
+  EventPayload get_payload(bool use_base64) const;
+  shared_ptr<Subject> get_subject() const;
+
   unsigned long long *m_true_timestamp;
   vector<SelfDescribingJson> m_context;
-  EventPayload get_payload(bool use_base64) const;
+  shared_ptr<Subject> m_subject;
 
   friend class Tracker;
 };

--- a/src/tracker.cpp
+++ b/src/tracker.cpp
@@ -95,6 +95,7 @@ void Tracker::set_subject(Subject *subject) {
 string Tracker::track(const Event &event) {
   EventPayload payload = event.get_payload(m_use_base64);
   vector<SelfDescribingJson> context = event.get_context();
+  auto event_subject = event.get_subject();
 
   // Add standard KV Pairs
   payload.add(SNOWPLOW_TRACKER_VERSION, SNOWPLOW_TRACKER_VERSION_LABEL);
@@ -105,6 +106,11 @@ string Tracker::track(const Event &event) {
   // Add Subject KV Pairs
   if (this->m_subject != NULL) {
     payload.add_map(this->m_subject->get_map());
+  }
+
+  // Add event subject pairs
+  if (event_subject) {
+    payload.add_map(event_subject->get_map());
   }
 
   // Add Client Session if available


### PR DESCRIPTION
Addresses issue #61 and adds an option to attach pointer to a Subject instance in individual events. Values from the event-level Subject take priority over those from the Tracker-level one.

## Docs update

You can also attach custom Subject information to individual events. In this way, you may track events describing different users or devices using the same tracker. Events can be assigned a shared C++ pointer to a Subject instance using the `set_subject` method. The following example shows how to attach a subject instance to a structured event (see [Tracking specific events](04-tracking-events.md) for more information on tracking events):

```cpp
auto subject = std::make_shared<Subject>();
subject->set_user_id("another-user");

StructuredEvent se("category", "action");
se.set_subject(subject);
```

[PR with docs updates is here on data-value-resources repo](https://github.com/snowplow-incubator/data-value-resources/pull/99).