### PR TITLE
Add integration tests using Snowplow Micro (close #57)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,34 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - uses: actions/setup-java@v1
+      with:
+        java-version: "11.x"
+
+    # -- Micro --
+    - name: Cache Micro
+      id: cache-micro
+      uses: actions/cache@v2
+      with:
+        path: micro.jar
+        key: ${{ runner.os }}-micro
+
+    - name: Get micro
+      if: steps.cache-micro.outputs.cache-hit != 'true'
+      run: curl -o micro.jar -L https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.1.2/snowplow-micro-1.1.2.jar
+
+    - name: Run Micro in background
+      run: java -jar micro.jar --collector-config test/integration/micro.conf --iglu test/integration/iglu.json &
+
+    - name: Wait on Micro endpoint
+      timeout-minutes: 2
+      run: while ! nc -z '0.0.0.0' 9090; do sleep 1; done
+
     - name: Make
       run: make
 
     - name: Run tests
-      run: make unit-tests
+      run: make tests
 
   test-windows:
     runs-on: windows-latest
@@ -23,20 +46,59 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - uses: actions/setup-java@v1
+      with:
+        java-version: "11.x"
+
+    # -- Micro --
+    - name: Cache Micro
+      id: cache-micro
+      uses: actions/cache@v2
+      with:
+        path: micro.jar
+        key: ${{ runner.os }}-micro
+
+    - name: Get micro
+      if: steps.cache-micro.outputs.cache-hit != 'true'
+      run: curl -o micro.jar -L https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.1.2/snowplow-micro-1.1.2.jar
+
     - name: Setup MSBuild and add to PATH
       uses: microsoft/setup-msbuild@v1.1
 
     - name: Run MSBuild
       run: msbuild .\snowplow-cpp-tracker.sln
 
-    - name: Run tests
-      run: .\x64\Debug\snowplow-cpp-tracker.exe
+    - name: Start Micro and run tests
+      run: javaw -jar micro.jar --collector-config test/integration/micro.conf --iglu test/integration/iglu.json; sleep 15; .\x64\Debug\snowplow-cpp-tracker.exe
 
   test-linux:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - uses: actions/setup-java@v1
+      with:
+        java-version: "11.x"
+
+    # -- Micro --
+    - name: Cache Micro
+      id: cache-micro
+      uses: actions/cache@v2
+      with:
+        path: micro.jar
+        key: ${{ runner.os }}-micro
+
+    - name: Get micro
+      if: steps.cache-micro.outputs.cache-hit != 'true'
+      run: curl -o micro.jar -L https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.1.2/snowplow-micro-1.1.2.jar
+
+    - name: Run Micro in background
+      run: java -jar micro.jar --collector-config test/integration/micro.conf --iglu test/integration/iglu.json &
+
+    - name: Wait on Micro endpoint
+      timeout-minutes: 2
+      run: while ! nc -z '0.0.0.0' 9090; do sleep 1; done
 
     - name: Install packages
       run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev uuid-dev
@@ -45,4 +107,4 @@ jobs:
       run: make
 
     - name: Run tests
-      run: make unit-tests
+      run: make tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         run: make
 
       - name: Run tests
-        run: make unit-tests
+        run: make tests
 
   release:
     needs: ["test"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: cpp
-os:
-  - osx
-before_install:
-  - sudo pip install cpp-coveralls
-script: 
-  - make unit-tests
-after_success:
-  - coveralls --include src --gcov-options '\-lp'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all unit-tests lcov-genhtml clean test-clean dist-clean
+.PHONY: all tests lcov-genhtml clean test-clean dist-clean
 
 build-dir = build/
 test-dir = $(build-dir)test/
@@ -73,12 +73,12 @@ $(performance-dir)$(performance-name): $(objcxx-objects) $(cxx-common-objects) $
 
 # Testing
 
-unit-tests: test-clean all
+tests: test-clean all
 	(cd $(test-dir); ./$(test-name))
 
 # Coverage
 
-lcov-genhtml: unit-tests
+lcov-genhtml: tests
 	mkdir -p $(coverage-dir)
 	lcov --capture --directory src --output-file $(coverage-dir)$(coverage-name)
 	genhtml $(coverage-dir)$(coverage-name) --output-directory $(coverage-dir) --demangle-cpp

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Check the tracked events in a [Snowplow Micro](https://docs.snowplowanalytics.co
  host> make
 ```
 
-This will create two executables - the first is the test-suite which can be executed with `make unit-tests`.
+This will create two executables - the first is the test-suite which can be executed with `make tests`.
 
 The other is an example program which will send one of every type of event to an endpoint of your choosing like so:
 
@@ -80,10 +80,10 @@ If you make changes only to a header file there is a chance it won't be picked u
  host> make
 ```
 
-To run the test suite:
+To run the test suite, first start a [Snowplow Micro](https://github.com/snowplow-incubator/snowplow-micro) instance and run:
 
 ```bash
- host> make unit-tests
+ host> make tests
 ```
 
 If you wish to generate a local code coverage report you will first need to install [lcov](http://ltp.sourceforge.net/coverage/lcov.php) on your host machine.  The easiest way to do this is using [brew](http://brew.sh/) under macOS:

--- a/snowplow-cpp-tracker.vcxproj
+++ b/snowplow-cpp-tracker.vcxproj
@@ -127,6 +127,8 @@
     <ClCompile Include="src\tracker.cpp" />
     <ClCompile Include="src\utils.cpp" />
     <ClCompile Include="test\http\test_http_client.cpp" />
+    <ClCompile Include="test\integration\integration_test.cpp" />
+    <ClCompile Include="test\integration\micro.cpp" />
     <ClCompile Include="test\client_session_test.cpp" />
     <ClCompile Include="test\configuration\emitter_configuration_test.cpp" />
     <ClCompile Include="test\configuration\network_configuration_test.cpp" />
@@ -178,6 +180,7 @@
     <ClInclude Include="src\tracker.hpp" />
     <ClInclude Include="src\utils.hpp" />
     <ClInclude Include="test\http\test_http_client.hpp" />
+    <ClInclude Include="test\integration\micro.hpp" />
     <ClInclude Include="test\catch.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/snowplow-cpp-tracker.vcxproj.filters
+++ b/snowplow-cpp-tracker.vcxproj.filters
@@ -90,6 +90,12 @@
     <ClCompile Include="test\http\test_http_client.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="test\integration\integration_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test\integration\micro.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="test\client_session_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -240,6 +246,9 @@
       <filter>header files</filter>
     </clinclude>
     <clinclude include="test\http\test_http_client.hpp">
+      <filter>header files</filter>
+    </clinclude>
+    <clinclude include="test\integration\micro.hpp">
       <filter>header files</filter>
     </clinclude>
   </ItemGroup>

--- a/test/integration/iglu.json
+++ b/test/integration/iglu.json
@@ -1,0 +1,20 @@
+{
+    "schema": "iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-0",
+    "data": {
+        "cacheSize": 500,
+        "repositories": [
+            {
+                "name": "Iglu Central",
+                "priority": 0,
+                "vendorPrefixes": [
+                    "com.snowplowanalytics"
+                ],
+                "connection": {
+                    "http": {
+                        "uri": "http://iglucentral.com"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/test/integration/integration_test.cpp
+++ b/test/integration/integration_test.cpp
@@ -1,0 +1,163 @@
+/*
+Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+
+This program is licensed to you under the Apache License Version 2.0,
+and you may not use this file except in compliance with the Apache License Version 2.0.
+You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the Apache License Version 2.0 is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+*/
+
+#include "../../src/snowplow.hpp"
+#include "micro.hpp"
+#include "../catch.hpp"
+
+using namespace snowplow;
+using std::invalid_argument;
+using std::runtime_error;
+using std::to_string;
+using std::this_thread::sleep_for;
+
+TEST_CASE("integration") {
+  SECTION("Tracks an event with desktop context") {
+    Micro::clear();
+
+    EmitterConfiguration emitter_config("test-tracker.db");
+    auto tracker = Snowplow::create_tracker(
+        TrackerConfiguration("snowplow-testing", "snowplow-test-suite", pc),
+        NetworkConfiguration(SNOWPLOW_MICRO_ENDPOINT),
+        emitter_config);
+
+    StructuredEvent sv("hello", "world");
+    string event_id = tracker->track(sv);
+    tracker->flush();
+
+    auto counts = Micro::get_good_and_bad_count();
+    REQUIRE(std::get<0>(counts) == 1);
+    REQUIRE(std::get<1>(counts) == 0);
+
+    auto good = Micro::get_good();
+    REQUIRE(good.size() == 1);
+    auto first = good.front();
+    auto event = first["event"].get<json>();
+    REQUIRE(event["platform"] == "pc");
+    REQUIRE(event["event_id"] == event_id);
+    REQUIRE(event["se_category"] == "hello");
+    REQUIRE(event["se_action"] == "world");
+
+    auto entities = event["contexts"].get<json>()["data"].get<list<json>>();
+    REQUIRE(entities.size() == 1);
+    REQUIRE(entities.front()["schema"] == SNOWPLOW_SCHEMA_DESKTOP_CONTEXT);
+    auto entity = entities.front()["data"].get<json>();
+    REQUIRE(entity["osType"] == Utils::get_os_type());
+
+    Snowplow::remove_tracker(tracker);
+  }
+
+  SECTION("Tracks events with session") {
+    Micro::clear();
+
+    EmitterConfiguration emitter_config("test-tracker.db");
+    TrackerConfiguration tracker_config("snowplow-testing", "snowplow-test-suite", pc);
+    tracker_config.set_desktop_context(false);
+    SessionConfiguration session_config("test-tracker.db");
+    auto tracker = Snowplow::create_tracker(
+        tracker_config,
+        NetworkConfiguration(SNOWPLOW_MICRO_ENDPOINT),
+        emitter_config,
+        session_config);
+
+    string event_id = tracker->track(StructuredEvent("hello", "world1"));
+    tracker->track(StructuredEvent("hello", "world2"));
+    tracker->flush();
+
+    auto counts = Micro::get_good_and_bad_count();
+    REQUIRE(std::get<0>(counts) == 2);
+    REQUIRE(std::get<1>(counts) == 0);
+
+    auto good = Micro::get_good();
+    REQUIRE(good.size() == 2);
+
+    // check first event session context
+    auto event = good.front()["event"].get<json>();
+    auto entities = event["contexts"].get<json>()["data"].get<list<json>>();
+    REQUIRE(entities.size() == 1);
+    REQUIRE(entities.front()["schema"] == SNOWPLOW_SCHEMA_CLIENT_SESSION);
+    auto entity1 = entities.front()["data"].get<json>();
+    REQUIRE(entity1["firstEventId"] == event_id);
+
+    // second event has the same session information
+    event = good.back()["event"].get<json>();
+    entities = event["contexts"].get<json>()["data"].get<list<json>>();
+    auto entity2 = entities.front()["data"].get<json>();
+    REQUIRE(entity2["firstEventId"] == event_id);
+    REQUIRE(entity2["userId"] == entity1["userId"]);
+    REQUIRE(entity2["sessionId"] == entity1["sessionId"]);
+
+    Snowplow::remove_tracker(tracker);
+  }
+
+  SECTION("Tracks an event with custom context") {
+    Micro::clear();
+
+    EmitterConfiguration emitter_config("test-tracker.db");
+    TrackerConfiguration tracker_config("snowplow-testing", "snowplow-test-suite", pc);
+    tracker_config.set_desktop_context(false);
+    auto tracker = Snowplow::create_tracker(
+        tracker_config,
+        NetworkConfiguration(SNOWPLOW_MICRO_ENDPOINT),
+        emitter_config);
+
+    const string link_click_schema = "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1";
+    const string media_player_schema = "iglu:com.snowplowanalytics.snowplow/media_player/jsonschema/1-0-0";
+    SelfDescribingEvent sde(SelfDescribingJson(
+      link_click_schema,
+      "{\"targetUrl\": \"http://a-target-url.com\"}"_json
+    ));
+    sde.set_context({SelfDescribingJson(
+        media_player_schema,
+        "{\"currentTime\": 0, \"duration\": 10, \"ended\": false, \"loop\": false, \"muted\": false, \"paused\": false, \"playbackRate\": 1, \"volume\": 100}"_json)});
+    string event_id = tracker->track(sde);
+    tracker->flush();
+
+    auto counts = Micro::get_good_and_bad_count();
+    REQUIRE(std::get<0>(counts) == 1);
+    REQUIRE(std::get<1>(counts) == 0);
+
+    auto good = Micro::get_good();
+    REQUIRE(good.size() == 1);
+    auto first = good.front();
+    auto event = first["event"].get<json>();
+    REQUIRE(event["unstruct_event"].get<json>()["data"].get<json>()["schema"] == link_click_schema);
+    auto entities = event["contexts"].get<json>()["data"].get<list<json>>();
+
+    REQUIRE(entities.size() == 1);
+    REQUIRE(entities.front()["schema"] == media_player_schema);
+    auto entity = entities.front()["data"].get<json>();
+    REQUIRE(entity["duration"] == 10);
+
+    Snowplow::remove_tracker(tracker);
+  }
+
+  SECTION("Tracks an event without flushing") {
+    Micro::clear();
+
+    auto tracker = Snowplow::create_tracker("snowplow-testing", SNOWPLOW_MICRO_ENDPOINT, POST, "test-tracker.db");
+
+    ScreenViewEvent event;
+    string name = "screen";
+    event.name = &name;
+    tracker->track(event);
+    sleep_for(milliseconds(500));
+
+    auto counts = Micro::get_good_and_bad_count();
+    REQUIRE(std::get<0>(counts) == 1);
+    REQUIRE(std::get<1>(counts) == 0);
+
+    Snowplow::remove_tracker(tracker);
+  }
+
+}

--- a/test/integration/micro.conf
+++ b/test/integration/micro.conf
@@ -1,0 +1,231 @@
+# 'collector' contains configuration options for the main Scala collector.
+collector {
+  # The collector runs as a web service specified on the following interface and port.
+  interface = "127.0.0.1"
+  port = "9090"
+
+  # optional SSL/TLS configuration
+  ssl {
+    enable = false
+    # whether to redirect HTTP to HTTPS
+    redirect = false
+    port = 9543
+  }
+
+  # The collector responds with a cookie to requests with a path that matches the 'vendor/version' protocol.
+  # The expected values are:
+  # - com.snowplowanalytics.snowplow/tp2 for Tracker Protocol 2
+  # - r/tp2 for redirects
+  # - com.snowplowanalytics.iglu/v1 for the Iglu Webhook
+  # Any path that matches the 'vendor/version' protocol will result in a cookie response, for use by custom webhooks
+  # downstream of the collector.
+  # But you can also map any valid (i.e. two-segment) path to one of the three defaults.
+  # Your custom path must be the key and the value must be one of the corresponding default paths. Both must be full
+  # valid paths starting with a leading slash.
+  # Pass in an empty map to avoid mapping.
+  paths {
+    # "/com.acme/track" = "/com.snowplowanalytics.snowplow/tp2"
+    # "/com.acme/redirect" = "/r/tp2"
+    # "/com.acme/iglu" = "/com.snowplowanalytics.iglu/v1"
+  }
+
+  # Configure the P3P policy header.
+  p3p {
+    policyRef = "/w3c/p3p.xml"
+    CP = "NOI DSP COR NID PSA OUR IND COM NAV STA"
+  }
+
+  # Cross domain policy configuration.
+  # If "enabled" is set to "false", the collector will respond with a 404 to the /crossdomain.xml
+  # route.
+  crossDomain {
+    enabled = false
+    # Domains that are granted access, *.acme.com will match http://acme.com and http://sub.acme.com
+    domains = [ "*" ]
+    # Whether to only grant access to HTTPS or both HTTPS and HTTP sources
+    secure = true
+  }
+
+  # The collector returns a cookie to clients for user identification
+  # with the following domain and expiration.
+  cookie {
+    enabled = true
+    expiration = "365 days"
+    # Network cookie name
+    name = "micro"
+    # The domain is optional and will make the cookie accessible to other
+    # applications on the domain. Comment out these lines to tie cookies to
+    # the collector's full domain.
+    # The domain is determined by matching the domains from the Origin header of the request
+    # to the list below. The first match is used. If no matches are found, the fallback domain will be used,
+    # if configured.
+    # If you specify a main domain, all subdomains on it will be matched.
+    # If you specify a subdomain, only that subdomain will be matched.
+    # Examples:
+    # domain.com will match domain.com, www.domain.com and secure.client.domain.com
+    # client.domain.com will match secure.client.domain.com but not domain.com or www.domain.com
+    domains = [
+        # "{{cookieDomain1}}" # e.g. "domain.com" -> any origin domain ending with this will be matched and domain.com will be returned
+        # "{{cookieDomain2}}" # e.g. "secure.anotherdomain.com" -> any origin domain ending with this will be matched and secure.anotherdomain.com will be returned
+        # ... more domains
+    ]
+    # ... more domains
+    # If specified, the fallback domain will be used if none of the Origin header hosts matches the list of
+    # cookie domains configured above. (For example, if there is no Origin header.)
+    # fallback-domain = "{{fallbackDomain}}"
+    secure = false
+    httpOnly = false
+    # The sameSite is optional. You can choose to not specify the attribute, or you can use `Strict`,
+    # `Lax` or `None` to limit the cookie sent context.
+    #   Strict: the cookie will only be sent along with "same-site" requests.
+    #   Lax: the cookie will be sent with same-site requests, and with cross-site top-level navigation.
+    #   None: the cookie will be sent with same-site and cross-site requests.
+    # sameSite = "{{cookieSameSite}}"
+  }
+
+  # If you have a do not track cookie in place, the Scala Stream Collector can respect it by
+  # completely bypassing the processing of an incoming request carrying this cookie, the collector
+  # will simply reply by a 200 saying "do not track".
+  # The cookie name and value must match the configuration below, where the names of the cookies must
+  # match entirely and the value could be a regular expression.
+  doNotTrackCookie {
+    enabled = false
+    name = "foo"
+    value = "bar"
+  }
+
+  # When enabled and the cookie specified above is missing, performs a redirect to itself to check
+  # if third-party cookies are blocked using the specified name. If they are indeed blocked,
+  # fallbackNetworkId is used instead of generating a new random one.
+  cookieBounce {
+    enabled = false
+    # The name of the request parameter which will be used on redirects checking that third-party
+    # cookies work.
+    name = "n3pc"
+    # Network user id to fallback to when third-party cookies are blocked.
+    fallbackNetworkUserId = "00000000-0000-4000-A000-000000000000"
+    # Optionally, specify the name of the header containing the originating protocol for use in the
+    # bounce redirect location. Use this if behind a load balancer that performs SSL termination.
+    # The value of this header must be http or https. Example, if behind an AWS Classic ELB.
+    # forwardedProtocolHeader = "X-Forwarded-Proto"
+  }
+
+  # When enabled, redirect prefix `r/` will be enabled and its query parameters resolved.
+  # Otherwise the request prefixed with `r/` will be dropped with `404 Not Found`
+  # Custom redirects configured in `paths` can still be used.
+  # enableDefaultRedirect = true
+
+  # When enabled, the redirect url passed via the `u` query parameter is scanned for a placeholder
+  # token. All instances of that token are replaced withe the network ID. If the placeholder isn't
+  # specified, the default value is `${SP_NUID}`.
+  redirectMacro {
+    enabled = false
+    # Optional custom placeholder token (defaults to the literal `${SP_NUID}`)
+    placeholder = "[TOKEN]"
+  }
+
+  # Customize response handling for requests for the root path ("/").
+  # Useful if you need to redirect to web content or privacy policies regarding the use of this collector.
+  rootResponse {
+    enabled = false
+    statusCode = 302
+    # Optional, defaults to empty map
+    headers = {
+      Location = "https://127.0.0.1/",
+      X-Custom = "something"
+    }
+    # Optional, defaults to empty string
+    body = "302, redirecting"
+  }
+
+  # Configuration related to CORS preflight requests
+  cors {
+    # The Access-Control-Max-Age response header indicates how long the results of a preflight
+    # request can be cached. -1 seconds disables the cache. Chromium max is 10m, Firefox is 24h.
+    accessControlMaxAge = 5 seconds
+  }
+
+  # Configuration of prometheus http metrics
+  prometheusMetrics {
+    # If metrics are enabled then all requests will be logged as prometheus metrics
+    # and '/metrics' endpoint will return the report about the requests
+    enabled = false
+    # Custom buckets for http_request_duration_seconds_bucket duration metric
+    #durationBucketsInSeconds = [0.1, 3, 10]
+  }
+
+  streams {
+    # Events which have successfully been collected will be stored in the good stream/topic
+    good = ""
+
+    # Events that are too big (w.r.t Kinesis 1MB limit) will be stored in the bad stream/topic
+    bad = ""
+
+    # Whether to use the incoming event's ip as the partition key for the good stream/topic
+    # Note: Nsq does not make use of partition key.
+    useIpAddressAsPartitionKey = false
+
+    # Enable the chosen sink by uncommenting the appropriate configuration
+    sink {
+      # Choose between kinesis, googlepubsub, kafka, nsq, or stdout.
+      # To use stdout, comment or remove everything in the "collector.streams.sink" section except
+      # "enabled" which should be set to "stdout".
+      enabled = stdout
+
+    }
+
+    # Incoming events are stored in a buffer before being sent to Kinesis/Kafka.
+    # Note: Buffering is not supported by NSQ.
+    # The buffer is emptied whenever:
+    # - the number of stored records reaches record-limit or
+    # - the combined size of the stored records reaches byte-limit or
+    # - the time in milliseconds since the buffer was last emptied reaches time-limit
+    buffer {
+      byteLimit = 100000
+      recordLimit = 40
+      timeLimit = 1000
+    }
+  }
+}
+
+# Akka has a variety of possible configuration options defined at
+# http://doc.akka.io/docs/akka/current/scala/general/configuration.html
+akka {
+  loglevel = DEBUG # 'OFF' for no logging, 'DEBUG' for all logging.
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+
+  # akka-http is the server the Stream collector uses and has configurable options defined at
+  # http://doc.akka.io/docs/akka-http/current/scala/http/configuration.html
+  http.server {
+    # To obtain the hostname in the collector, the 'remote-address' header
+    # should be set. By default, this is disabled, and enabling it
+    # adds the 'Remote-Address' header to every request automatically.
+    remote-address-header = on
+
+    raw-request-uri-header = on
+
+    # Define the maximum request length (the default is 2048)
+    parsing {
+      max-uri-length = 32768
+      uri-parsing-mode = relaxed
+    }
+  }
+
+  # By default setting `collector.ssl` relies on JSSE (Java Secure Socket
+  # Extension) to enable secure communication.
+  # To override the default settings set the following section as per
+  # https://lightbend.github.io/ssl-config/ExampleSSLConfig.html
+  # ssl-config {
+  #   debug = {
+  #     ssl = true
+  #   }
+  #   keyManager = {
+  #     stores = [
+  #       {type = "PKCS12", classpath = false, path = "/etc/ssl/mycert.p12", password = "mypassword" }
+  #     ]
+  #   }
+  #   loose {
+  #     disableHostnameVerification = false
+  #   }
+  # }
+}

--- a/test/integration/micro.cpp
+++ b/test/integration/micro.cpp
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+
+This program is licensed to you under the Apache License Version 2.0,
+and you may not use this file except in compliance with the Apache License Version 2.0.
+You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the Apache License Version 2.0 is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+*/
+
+#include "micro.hpp"
+
+using namespace snowplow;
+
+void Micro::clear() {
+  request("/micro/reset");
+}
+
+tuple<int, int> Micro::get_good_and_bad_count() {
+  string response_str = request("/micro/all");
+  json response = json::parse(response_str);
+  int good = response["good"].get<int>();
+  int bad = response["bad"].get<int>();
+  return std::make_tuple(good, bad);
+}
+
+list<json> Micro::get_good() {
+  string response_str = request("/micro/good");
+  return json::parse(response_str).get<list<json>>();
+}
+
+static size_t write_data(void *data, size_t byte_size, size_t n_bytes, string *body) {
+  ((std::string*)body)->append((char*)data, byte_size * n_bytes);
+  return byte_size * n_bytes;
+}
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+#include <WinInet.h>
+#include <tchar.h>
+
+string Micro::request(const string &path) {
+  HINTERNET h_internet = InternetOpen(
+      TEXT("Test"),
+      INTERNET_OPEN_TYPE_DIRECT,
+      NULL,
+      NULL,
+      0);
+
+  HINTERNET h_connect = InternetConnect(
+      h_internet,
+      TEXT(SNOWPLOW_MICRO_HOSTNAME.c_str()),
+      9090,
+      NULL,
+      NULL,
+      INTERNET_SERVICE_HTTP,
+      0,
+      NULL);
+
+  HINTERNET h_request = HttpOpenRequest(
+      h_connect,
+      TEXT("GET"),
+      TEXT(path.c_str()),
+      NULL,
+      NULL,
+      NULL,
+      0 | INTERNET_FLAG_RELOAD,
+      0);
+
+  LPCSTR hdrs = TEXT("Content-Type: application/json; charset=utf-8");
+  BOOL is_sent = HttpSendRequest(h_request, hdrs, strlen(hdrs), NULL, 0);
+
+  string response;
+  const int buf_len = 1024;
+  char buff[buf_len];
+
+  BOOL is_more = true;
+  DWORD bytes_read = -1;
+
+  while (is_more && bytes_read != 0) {
+    is_more = InternetReadFile(h_request, buff, buf_len, &bytes_read);
+    response.append(buff, bytes_read);
+  }
+
+  InternetCloseHandle(h_request);
+  InternetCloseHandle(h_connect);
+  InternetCloseHandle(h_internet);
+
+  return response;
+}
+
+#else
+
+#include <curl/curl.h>
+
+string Micro::request(const string &path) {
+  CURL *curl = curl_easy_init();
+
+  curl_easy_setopt(curl, CURLOPT_HTTPGET, 1);
+
+  string read_buffer;
+  string full_url = SNOWPLOW_MICRO_ENDPOINT + path;
+  curl_easy_setopt(curl, CURLOPT_URL, full_url.c_str());
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &read_buffer);
+
+  // send the request
+  CURLcode res = curl_easy_perform(curl);
+  long status_code;
+  if (res == CURLE_OK) {
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
+  }
+  
+  // cleanup
+  curl_easy_cleanup(curl);
+
+  return read_buffer;
+}
+#endif

--- a/test/integration/micro.hpp
+++ b/test/integration/micro.hpp
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+
+This program is licensed to you under the Apache License Version 2.0,
+and you may not use this file except in compliance with the Apache License Version 2.0.
+You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the Apache License Version 2.0 is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+*/
+
+#ifndef MICRO_H
+#define MICRO_H
+
+#include <string>
+#include <list>
+#include "../../include/json.hpp"
+
+using std::string;
+using std::tuple;
+using std::list;
+using nlohmann::json;
+
+namespace snowplow {
+const string SNOWPLOW_MICRO_HOSTNAME = "127.0.0.1";
+const string SNOWPLOW_MICRO_DOMAIN = SNOWPLOW_MICRO_HOSTNAME + ":9090";
+const string SNOWPLOW_MICRO_ENDPOINT = "http://" + SNOWPLOW_MICRO_DOMAIN;
+
+class Micro {
+public:
+    static void clear();
+    static tuple<int, int> get_good_and_bad_count();
+    static list<json> get_good();
+
+private:
+    static string request(const string &path);
+};
+}
+
+#endif


### PR DESCRIPTION
This addresses issue #57 and adds integration tests using Snowplow Micro.

I added integration tests as part of the other tests – they are run along with unit tests using `make tests` (before it was `make unit-tests`). They expect Snowplow Micro to be running on localhost.

The integration tests are also run in Github actions. The actions spin up a Micro instance and run the tests as usual.