### PR TITLE
Add support for storing cookies in HTTP clients (close #78)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,8 @@ SET(SNOWPLOW_SOURCES
 
 IF (APPLE)
    SET(SNOWPLOW_SOURCES ${SNOWPLOW_SOURCES}
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/snowplow/detail/utils/utils_macos.mm)
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/snowplow/detail/utils/utils_macos.mm
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/snowplow/detail/http/request_macos.mm)
 ENDIF()
 
 add_library(snowplow ${SNOWPLOW_SOURCES})
@@ -95,8 +96,6 @@ target_link_libraries(snowplow Threads::Threads)
 if (APPLE)
     find_library(COREFOUNDATION CoreFoundation)
     target_link_libraries(snowplow ${COREFOUNDATION})
-    find_library(CFNETWORK CFNetwork)
-    target_link_libraries(snowplow ${CFNETWORK})
     find_library(FOUNDATION Foundation)
     target_link_libraries(snowplow ${FOUNDATION})
     find_library(CORESERVICES CoreServices)

--- a/docs/02-initialisation.md
+++ b/docs/02-initialisation.md
@@ -111,6 +111,7 @@ It further provides 2 optional setter functions:
 |---|---|---|
 | `collector_url` | Full URL of the Snowplow collector including the protocol (or defaults to HTTPS if protocol not present). | None |
 | `method` | HTTP method to use when sending events to collector – GET or POST. | POST |
+| `curl_cookie_file` | Path to a file where to store cookies in case http_client is nullptr and the CURL HTTP client is used – only relevant under Linux (CURL is not used under Windows and macOS) | In-memory cookie storage with CURL on Linux, platform native storage on Windows and macOS |
 
 Additionally, it provides the following setter functions:
 
@@ -201,6 +202,7 @@ Accepts an argument of an Emitter instance pointer; if the object is `NULL` wi
 | `byte_limit_post` | The byte limit when sending a POST request | No | 40000 bytes |
 | `byte_limit_get` | The byte limit when sending a GET request | No | 40000 bytes |
 | `http_client` | Unique pointer to a custom HTTP client to send GET and POST requests with | No | Platform-specific implementation. |
+| `curl_cookie_file` | Path to a file where to store cookies in case http_client is nullptr and the CURL HTTP client is used – only relevant under Linux (CURL is not used under Windows and macOS) | No | In-memory cookie storage with CURL on Linux, platform native storage on Windows and macOS |
 
 ### Subject
 

--- a/include/snowplow/configuration/network_configuration.cpp
+++ b/include/snowplow/configuration/network_configuration.cpp
@@ -18,8 +18,9 @@ using namespace snowplow;
 
 using std::transform;
 
-NetworkConfiguration::NetworkConfiguration(const string &collector_url, Method method) {
+NetworkConfiguration::NetworkConfiguration(const string &collector_url, Method method, const string &curl_cookie_file) {
   m_method = method;
+  m_curl_cookie_file = curl_cookie_file;
 
   string collector_url_lower = collector_url;
   transform(collector_url_lower.begin(), collector_url_lower.end(), collector_url_lower.begin(), ::tolower);

--- a/include/snowplow/configuration/network_configuration.hpp
+++ b/include/snowplow/configuration/network_configuration.hpp
@@ -34,8 +34,9 @@ public:
    * 
    * @param collector_url Full URL of the Snowplow collector including the protocol (or defaults to HTTPS if protocol not present).
    * @param method HTTP method to use when sending events to collector – GET or POST.
+   * @param curl_cookie_file Path to a file where to store cookies in case the CURL HTTP client is used – only relevant under Linux (CURL is not used under Windows and macOS)
    */
-  NetworkConfiguration(const string &collector_url, Method method = POST);
+  NetworkConfiguration(const string &collector_url, Method method = POST, const string &curl_cookie_file = "");
 
   /**
    * @brief Get the collector hostname without the protocol.
@@ -59,6 +60,11 @@ public:
   Protocol get_protocol() const { return m_protocol; }
 
   /**
+   * @return string Path to a file where to store cookies in case the CURL HTTP client is used – only relevant under Linux (CURL is not used under Windows and macOS)
+   */
+  string get_curl_cookie_file() const { return m_curl_cookie_file; }
+
+  /**
    * @brief Set custom HTTP client.
    * 
    * @param http_client Unique pointer to a custom HTTP client to send GET and POST requests with.
@@ -74,6 +80,7 @@ private:
   unique_ptr<HttpClient> move_http_client() { return m_http_client ? move(m_http_client) : nullptr; }
 
   string m_collector_hostname;
+  string m_curl_cookie_file;
   Method m_method;
   Protocol m_protocol;
   unique_ptr<HttpClient> m_http_client;

--- a/include/snowplow/detail/http/request_macos.mm
+++ b/include/snowplow/detail/http/request_macos.mm
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+
+This program is licensed to you under the Apache License Version 2.0,
+and you may not use this file except in compliance with the Apache License Version 2.0.
+You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the Apache License Version 2.0 is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+*/
+
+#if defined(__APPLE__)
+
+#import "request_macos_interface.h"
+#import "../../constants.hpp"
+#import <Foundation/Foundation.h>
+
+int snowplow::make_request(bool is_post, const string &url, const string &post_data) {
+    NSString *nsUrl = [NSString stringWithUTF8String:url.c_str()];
+    NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:nsUrl]];
+    [urlRequest setValue:@"Snowplow C++ Tracker (macOS)" forHTTPHeaderField:@"User-Agent"];
+    [urlRequest setValue:@"keep-alive" forHTTPHeaderField:@"Connection"];
+
+    if (is_post) {
+        NSData *data = [NSData dataWithBytes:post_data.data() length:post_data.length()];
+        NSString *contentType = [NSString stringWithUTF8String:SNOWPLOW_POST_CONTENT_TYPE.c_str()];
+        [urlRequest setValue:contentType forHTTPHeaderField:@"Content-Type"];
+        [urlRequest setValue:[NSString stringWithFormat:@"%@", @(post_data.length()).stringValue] forHTTPHeaderField:@"Content-Length"];
+        [urlRequest setHTTPMethod:@"POST"];
+        [urlRequest setHTTPBody:data];
+    } else {
+        [urlRequest setHTTPMethod:@"GET"];
+    }
+
+    __block NSHTTPURLResponse *httpResponse = nil;
+    __block NSError *connectionError = nil;
+    dispatch_semaphore_t sem;
+
+    sem = dispatch_semaphore_create(0);
+
+    [[[NSURLSession sharedSession] dataTaskWithRequest:urlRequest
+                                        completionHandler:^(NSData *data, NSURLResponse *urlResponse, NSError *error) {
+
+        connectionError = error;
+        httpResponse = (NSHTTPURLResponse*)urlResponse;
+
+        dispatch_semaphore_signal(sem);
+    }] resume];
+
+    dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+
+    return [httpResponse statusCode];
+}
+
+#endif

--- a/include/snowplow/detail/http/request_macos_interface.h
+++ b/include/snowplow/detail/http/request_macos_interface.h
@@ -11,31 +11,19 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#ifndef HTTP_CLIENT_APPLE_H
-#define HTTP_CLIENT_APPLE_H
-#if defined(__APPLE__)
+#ifndef REQUEST_MACOS_INTERFACE_H
+#define REQUEST_MACOS_INTERFACE_H
 
-#include "http_client.hpp"
+#if defined(__APPLE__)
 
 #include <string>
 
 using std::string;
-using std::list;
 
 namespace snowplow {
-/**
- * @brief HTTP client for making requests to Snowplow Collector using Apple Core Foundation APIs.
- * 
- * This HTTP client is only compatible with Apple operating systems.
- */
-class HttpClientApple : public HttpClient {
-public:
-  ~HttpClientApple() {}
-
-protected:
-  HttpRequestResult http_request(const RequestMethod method, const CrackedUrl url, const string & query_string, const string & post_data, list<int> row_ids, bool oversize);
-};
+int make_request(bool is_post, const string &url, const string &post_data);
 }
 
 #endif
+
 #endif

--- a/include/snowplow/emitter/emitter.hpp
+++ b/include/snowplow/emitter/emitter.hpp
@@ -81,9 +81,11 @@ public:
    * @param byte_limit_post The byte limit when sending a POST request
    * @param byte_limit_get The byte limit when sending a GET request
    * @param http_client Unique pointer to a custom HTTP client to send GET and POST requests with
+   * @param curl_cookie_file Path to a file where to store cookies in case http_client is nullptr and the CURL HTTP client is used – only relevant under Linux (CURL is not used under Windows and macOS)
    */
   Emitter(shared_ptr<EventStore> event_store, const string & uri, Method method = POST, Protocol protocol = HTTPS, int batch_size = SNOWPLOW_EMITTER_DEFAULT_BATCH_SIZE, 
-    int byte_limit_post = SNOWPLOW_EMITTER_DEFAULT_BYTE_LIMIT_POST, int byte_limit_get = SNOWPLOW_EMITTER_DEFAULT_BYTE_LIMIT_GET, unique_ptr<HttpClient> http_client = nullptr);
+    int byte_limit_post = SNOWPLOW_EMITTER_DEFAULT_BYTE_LIMIT_POST, int byte_limit_get = SNOWPLOW_EMITTER_DEFAULT_BYTE_LIMIT_GET,
+    unique_ptr<HttpClient> http_client = nullptr, const string &curl_cookie_file = "");
 
   ~Emitter();
 

--- a/include/snowplow/http/http_client_apple.cpp
+++ b/include/snowplow/http/http_client_apple.cpp
@@ -13,84 +13,23 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #if defined(__APPLE__)
 #include "http_client_apple.hpp"
-#include "../constants.hpp"
-
-#include <CoreFoundation/CoreFoundation.h>
-#include <CFNetwork/CFNetwork.h>
-#include <CFNetwork/CFHTTPStream.h>
+#include "../detail/http/request_macos_interface.h"
 
 using namespace snowplow;
-using std::cerr;
-using std::endl;
-using std::lock_guard;
-
-const string HttpClientApple::TRACKER_AGENT = string("Snowplow C++ Tracker (macOS)");
 
 HttpRequestResult HttpClientApple::http_request(const RequestMethod method, CrackedUrl url, const string &query_string, const string &post_data, list<int> row_ids, bool oversize) {
-
-  // Get final url
   string final_url = url.to_string();
   if (method == GET) {
     final_url += "?" + query_string;
   }
 
-  // Create request
-  CFStringRef cf_url_str = CFStringCreateWithBytes(kCFAllocatorDefault, (const unsigned char *)final_url.c_str(), final_url.length(), kCFStringEncodingUTF8, false);
-  CFStringRef cf_content_type_str = CFStringCreateWithBytes(kCFAllocatorDefault, (const unsigned char *)SNOWPLOW_POST_CONTENT_TYPE.c_str(), SNOWPLOW_POST_CONTENT_TYPE.length(), kCFStringEncodingUTF8, false);
-  CFStringRef cf_user_agent_str = CFStringCreateWithBytes(kCFAllocatorDefault, (const unsigned char *)HttpClientApple::TRACKER_AGENT.c_str(), HttpClientApple::TRACKER_AGENT.length(), kCFStringEncodingUTF8, false);
+  int status_code = make_request(
+    method == POST,
+    final_url,
+    post_data
+  );
 
-  CFURLRef cf_url = CFURLCreateWithString(kCFAllocatorDefault, cf_url_str, NULL);
-  CFHTTPMessageRef cf_http_req;
-
-  if (method == GET) {
-    cf_http_req = CFHTTPMessageCreateRequest(kCFAllocatorDefault, CFSTR("GET"), cf_url, kCFHTTPVersion1_1);
-  } else {
-    cf_http_req = CFHTTPMessageCreateRequest(kCFAllocatorDefault, CFSTR("POST"), cf_url, kCFHTTPVersion1_1);
-    CFDataRef cf_post_data = CFDataCreate(kCFAllocatorDefault, (const UInt8 *)post_data.data(), post_data.size());
-    CFHTTPMessageSetBody(cf_http_req, cf_post_data);
-    if (cf_post_data) {
-      CFRelease(cf_post_data);
-    }
-    CFHTTPMessageSetHeaderFieldValue(cf_http_req, CFSTR("Content-Type"), cf_content_type_str);
-  }
-  CFHTTPMessageSetHeaderFieldValue(cf_http_req, CFSTR("User-Agent"), cf_user_agent_str);
-  CFHTTPMessageSetHeaderFieldValue(cf_http_req, CFSTR("Connection"), CFSTR("keep-alive"));
-
-  CFReadStreamRef cf_read_stream = CFReadStreamCreateForHTTPRequest(kCFAllocatorDefault, cf_http_req);
-  CFMutableDataRef cf_data_resp = CFDataCreateMutable(kCFAllocatorDefault, 0);
-
-  // Send request
-  CFReadStreamOpen(cf_read_stream);
-  CFIndex num_bytes_read;
-  do {
-    const int buff_size = 1024;
-    UInt8 buff[buff_size];
-    num_bytes_read = CFReadStreamRead(cf_read_stream, buff, buff_size);
-
-    if (num_bytes_read > 0) {
-      CFDataAppendBytes(cf_data_resp, buff, num_bytes_read);
-    } else if (num_bytes_read < 0) {
-      CFStreamError error = CFReadStreamGetError(cf_read_stream);
-      cerr << error.error << endl;
-    }
-  } while (num_bytes_read > 0);
-
-  // Process result
-  CFHTTPMessageRef cf_http_resp = (CFHTTPMessageRef)CFReadStreamCopyProperty(cf_read_stream, kCFStreamPropertyHTTPResponseHeader);
-  int cf_status_code = CFHTTPMessageGetResponseStatusCode(cf_http_resp);
-
-  // Release resources
-  CFReadStreamClose(cf_read_stream);
-  CFRelease(cf_url_str);
-  CFRelease(cf_content_type_str);
-  CFRelease(cf_user_agent_str);
-  CFRelease(cf_url);
-  CFRelease(cf_http_req);
-  CFRelease(cf_read_stream);
-  CFRelease(cf_data_resp);
-  CFRelease(cf_http_resp);
-
-  return HttpRequestResult(0, cf_status_code, row_ids, oversize);
+  return HttpRequestResult(0, status_code, row_ids, oversize);
 }
 
 #endif

--- a/include/snowplow/http/http_client_curl.cpp
+++ b/include/snowplow/http/http_client_curl.cpp
@@ -20,8 +20,9 @@ using namespace snowplow;
 using std::cerr;
 using std::endl;
 
-HttpClientCurl::HttpClientCurl() {
+HttpClientCurl::HttpClientCurl(const string &cookie_file) {
   curl_global_init(CURL_GLOBAL_ALL);
+  m_cookie_file = cookie_file;
 }
 
 HttpClientCurl::~HttpClientCurl() {
@@ -55,10 +56,19 @@ HttpRequestResult HttpClientCurl::http_request(const RequestMethod method, Crack
   }
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+  curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   std::string full_url = full_url_stream.str();
   curl_easy_setopt(curl, CURLOPT_URL, full_url.c_str());
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data);
+
+  // cookie jar
+  if (m_cookie_file.empty()) {
+    curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
+  } else {
+    curl_easy_setopt(curl, CURLOPT_COOKIEFILE, m_cookie_file.c_str());
+    curl_easy_setopt(curl, CURLOPT_COOKIEJAR, m_cookie_file.c_str());
+  }
 
   // send the request
   CURLcode res = curl_easy_perform(curl);

--- a/include/snowplow/http/http_client_curl.hpp
+++ b/include/snowplow/http/http_client_curl.hpp
@@ -32,13 +32,21 @@ namespace snowplow {
  */
 class HttpClientCurl : public HttpClient {
 public:
-  HttpClientCurl();
+  /**
+   * @brief Construct a new Http Client Curl object
+   * 
+   * @param cookie_file Path to a file where to store cookies. If empty string, cookies will be stored in-memory.
+   */
+  HttpClientCurl(const string &cookie_file = "");
   ~HttpClientCurl();
 
   static const string TRACKER_AGENT;
 
 protected:
   HttpRequestResult http_request(const RequestMethod method, const CrackedUrl url, const string & query_string, const string & post_data, list<int> row_ids, bool oversize);
+
+private:
+  string m_cookie_file;
 };
 }
 

--- a/test/integration/integration_test.cpp
+++ b/test/integration/integration_test.cpp
@@ -156,4 +156,41 @@ TEST_CASE("integration") {
     Snowplow::remove_tracker(tracker);
   }
 
+  SECTION("Stores cookies and maintains network_userid") {
+    Micro::clear();
+
+    NetworkConfiguration network_config(SNOWPLOW_MICRO_ENDPOINT, POST, "cookies.txt");
+    EmitterConfiguration emitter_config("test-tracker.db");
+    TrackerConfiguration tracker_config("snowplow-testing", "snowplow-test-suite", pc);
+    auto tracker = Snowplow::create_tracker(tracker_config, network_config, emitter_config);
+
+    tracker->track(StructuredEvent("hello", "1"));
+    sleep_for(milliseconds(500));
+    tracker->track(StructuredEvent("hello", "2"));
+    tracker->flush();
+
+    auto counts = Micro::get_good_and_bad_count();
+    REQUIRE(std::get<0>(counts) == 2);
+    REQUIRE(std::get<1>(counts) == 0);
+
+    auto good = Micro::get_good();
+    auto first = good.front();
+    auto second = good.back();
+
+    auto get_network_user_id = [](json item) {
+      auto event = item["event"].get<json>();
+      return event["network_userid"].get<string>();
+    };
+    auto get_collector_timestamp = [](json item) {
+      auto event = item["event"].get<json>();
+      return event["collector_tstamp"].get<string>();
+    };
+
+    REQUIRE(get_network_user_id(first).size() > 5);
+    REQUIRE(get_network_user_id(first) == get_network_user_id(second));
+    REQUIRE(get_collector_timestamp(first) != get_collector_timestamp(second));
+
+    Snowplow::remove_tracker(tracker);
+  }
+
 }


### PR DESCRIPTION
This PR addresses issue #78 and adds support for cookies returned from the collector which enables the `network_userid` property to be consistent.

The cookie implementation is different for each HTTP client. There are three clients:

1. The Windows HTTP client already had cookie support by default. So no changes were required there.
2. The Apple HTTP client was using older APIs that do not have cookie support. I changed the implementation to use the shared `NSURLSession` as on the iOS tracker which has cookie support by default.
3. The CURL client used on Linux has optional Cookie support. It can use a local file where to store cookies or use in-memory storage (if the file path is empty). I added a parameter to `NetworkConfiguration` to configure the cookie path for the CURL client (the parameter is ignored on Windows and macOS).