### PR TITLE
Add eventIndex and firstEventTimestamp properties to client sessions (close #80)

### DIFF
--- a/docs/06-client-sessions.md
+++ b/docs/06-client-sessions.md
@@ -16,16 +16,18 @@ To set the background/foreground state you will need to detect this and then set
 client_session.set_is_background(true || false);
 ```
 
-When client sessions are used, the [`client_session`](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1) context entity is added to all tracked event. This entity consists of the following properties:
+When client sessions are used, the [`client_session`](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2) context entity is added to all tracked event. This entity consists of the following properties:
 
 | Attribute | Description | Required? |
 |---|---|---|
 | `userId` | An identifier for the user of the session. | Yes |
 | `sessionId` | An identifier (UUID) for the session. | Yes |
 | `sessionIndex` | The index of the current session for this user. | Yes |
+| `eventIndex` | Optional index of the current event in the session. Signifies the order of events in which they were tracked. | No |
 | `previousSessionId` | The previous session identifier (UUID) for this user. | No |
 | `storageMechanism` | The mechanism that the session information has been stored on the device. | Yes |
 | `firstEventId` | The optional identifier (UUID) of the first event id for this session. | No |
+| `firstEventTimestamp` | Optional date-time timestamp of when the first event in the session was tracked. | No |
 
 ## Session store
 

--- a/include/snowplow/client_session.cpp
+++ b/include/snowplow/client_session.cpp
@@ -14,6 +14,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "client_session.hpp"
 #include "constants.hpp"
 #include "detail/utils/utils.hpp"
+#include <chrono>
 
 using namespace snowplow;
 using std::lock_guard;
@@ -38,6 +39,7 @@ ClientSession::ClientSession(shared_ptr<SessionStore> session_store, unsigned lo
   this->m_session_storage = "SQLITE";
   this->m_is_background = false;
   this->m_is_new_session = true;
+  this->m_event_index = 0;
 
   // Check for existing session
   auto session = m_session_store->get_session();
@@ -67,7 +69,7 @@ void ClientSession::start_new_session() {
   this->m_is_new_session = true;
 }
 
-SelfDescribingJson ClientSession::update_and_get_session_context(const string &event_id) {
+SelfDescribingJson ClientSession::update_and_get_session_context(const string &event_id, unsigned long long event_timestamp) {
   json session_context_data;
   bool save_to_storage = false;
 
@@ -75,7 +77,7 @@ SelfDescribingJson ClientSession::update_and_get_session_context(const string &e
     lock_guard<mutex> guard(this->m_safe_get);
 
     if (this->should_update_session()) {
-      this->update_session(event_id);
+      this->update_session(event_id, event_timestamp);
       save_to_storage = true;
     }
     this->update_last_session_check_at();
@@ -85,6 +87,10 @@ SelfDescribingJson ClientSession::update_and_get_session_context(const string &e
   if (save_to_storage) {
     m_session_store->set_session(session_context_data);
   }
+
+  m_event_index++;
+  session_context_data[SNOWPLOW_SESSION_EVENT_INDEX] = m_event_index;
+
   SelfDescribingJson sdj(SNOWPLOW_SCHEMA_CLIENT_SESSION, session_context_data);
   return sdj;
 }
@@ -120,12 +126,13 @@ void ClientSession::update_last_session_check_at() {
   this->m_last_session_check_at = Utils::get_unix_epoch_ms();
 }
 
-void ClientSession::update_session(const string &event_id) {
+void ClientSession::update_session(const string &event_id, unsigned long long event_timestamp) {
   this->m_is_new_session = false;
   this->m_first_event_id = event_id;
   this->m_previous_session_id = this->m_current_session_id;
   this->m_current_session_id = Utils::get_uuid4();
   this->m_session_index += 1;
+  this->m_event_index = 0;
 
   // update session context data
   json j;
@@ -144,6 +151,7 @@ void ClientSession::update_session(const string &event_id) {
   if (this->m_first_event_id != "") {
     j[SNOWPLOW_SESSION_FIRST_ID] = this->m_first_event_id;
   }
+  j[SNOWPLOW_SESSION_FIRST_TIMESTAMP] = Utils::get_unix_epoch_ms_as_datetime_string(event_timestamp);
 
   this->m_session_context_data = j;
 }

--- a/include/snowplow/client_session.cpp
+++ b/include/snowplow/client_session.cpp
@@ -72,6 +72,7 @@ void ClientSession::start_new_session() {
 SelfDescribingJson ClientSession::update_and_get_session_context(const string &event_id, unsigned long long event_timestamp) {
   json session_context_data;
   bool save_to_storage = false;
+  int event_index = 0;
 
   {
     lock_guard<mutex> guard(this->m_safe_get);
@@ -82,14 +83,16 @@ SelfDescribingJson ClientSession::update_and_get_session_context(const string &e
     }
     this->update_last_session_check_at();
     session_context_data = this->m_session_context_data;
+
+    m_event_index++;
+    event_index = m_event_index;
   }
 
   if (save_to_storage) {
     m_session_store->set_session(session_context_data);
   }
 
-  m_event_index++;
-  session_context_data[SNOWPLOW_SESSION_EVENT_INDEX] = m_event_index;
+  session_context_data[SNOWPLOW_SESSION_EVENT_INDEX] = event_index;
 
   SelfDescribingJson sdj(SNOWPLOW_SCHEMA_CLIENT_SESSION, session_context_data);
   return sdj;

--- a/include/snowplow/client_session.hpp
+++ b/include/snowplow/client_session.hpp
@@ -34,7 +34,7 @@ namespace snowplow {
  * Activity is determined by how often events are sent with the Tracker. Sessions are updated on on each tracked event.
  * 
  * Tracker automatically appends session information as a context entity to each tracked event.
- * Schema for the context entity: iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1
+ * Schema for the context entity: iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2
  */
 class ClientSession {
 public:
@@ -89,9 +89,10 @@ public:
    * foreground timeout if in foreground). Each update is persisted in the SQLite database.
    *
    * @param event_id Tracked event ID
+   * @param event_timestamp Tracked event timestamp
    * @return SelfDescribingJson JSON with the session context
    */
-  SelfDescribingJson update_and_get_session_context(const string &event_id);
+  SelfDescribingJson update_and_get_session_context(const string &event_id, unsigned long long event_timestamp);
 
   /**
    * @brief Get the background timeout setting
@@ -118,6 +119,7 @@ private:
   string m_current_session_id;
   string m_previous_session_id;
   unsigned long long m_session_index;
+  unsigned long long m_event_index;
   string m_session_storage;
   string m_first_event_id;
 
@@ -129,10 +131,11 @@ private:
 
   // Session management
   mutex m_safe_get;
-  void update_session(const string &event_id);
+  void update_session(const string &event_id, unsigned long long event_timestamp);
   void update_last_session_check_at();
   bool should_update_session();
   unsigned long long get_timeout();
+  string timestamp_to_string(unsigned long long timestamp);
 };
 }
 

--- a/include/snowplow/constants.hpp
+++ b/include/snowplow/constants.hpp
@@ -35,7 +35,7 @@ const string SNOWPLOW_GET_PROTOCOL_PATH = "i";
 const string SNOWPLOW_SCHEMA_PAYLOAD_DATA = "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4";
 const string SNOWPLOW_SCHEMA_CONTEXTS = "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1";
 const string SNOWPLOW_SCHEMA_UNSTRUCT_EVENT = "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0";
-const string SNOWPLOW_SCHEMA_CLIENT_SESSION = "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1";
+const string SNOWPLOW_SCHEMA_CLIENT_SESSION = "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2";
 const string SNOWPLOW_SCHEMA_DESKTOP_CONTEXT = "iglu:com.snowplowanalytics.snowplow/desktop_context/jsonschema/1-0-0";
 
 // event types
@@ -99,8 +99,10 @@ const string SNOWPLOW_SESSION_USER_ID = "userId";
 const string SNOWPLOW_SESSION_ID = "sessionId";
 const string SNOWPLOW_SESSION_PREVIOUS_ID = "previousSessionId";
 const string SNOWPLOW_SESSION_INDEX = "sessionIndex";
+const string SNOWPLOW_SESSION_EVENT_INDEX = "eventIndex";
 const string SNOWPLOW_SESSION_STORAGE = "storageMechanism";
 const string SNOWPLOW_SESSION_FIRST_ID = "firstEventId";
+const string SNOWPLOW_SESSION_FIRST_TIMESTAMP = "firstEventTimestamp";
 const unsigned long long SNOWPLOW_SESSION_DEFAULT_TIMEOUT = 30 * 1000 * 1000; // 30 minutes
 
 // emitter defaults

--- a/include/snowplow/detail/utils/utils.cpp
+++ b/include/snowplow/detail/utils/utils.cpp
@@ -280,3 +280,14 @@ string Utils::get_device_model() {
 
 #endif
 #endif
+
+string Utils::get_unix_epoch_ms_as_datetime_string(unsigned long long timestamp_ms) {
+  std::time_t time = timestamp_ms / 1000;
+  std::tm* t = std::gmtime(&time);
+  int ms = timestamp_ms % 1000;
+
+  stringstream ss;
+  ss << std::put_time(t, "%Y-%m-%dT%H:%M:%S")
+    << '.' << std::setfill('0') << std::setw(3) << ms << "Z";
+  return ss.str();
+}

--- a/include/snowplow/detail/utils/utils.hpp
+++ b/include/snowplow/detail/utils/utils.hpp
@@ -68,6 +68,7 @@ public:
   static string get_device_manufacturer();
   static string get_device_model();
   static int get_device_processor_count();
+  static string get_unix_epoch_ms_as_datetime_string(unsigned long long timestamp_ms);
 
 private:
   static SelfDescribingJson *m_desktop_context;

--- a/include/snowplow/tracker.cpp
+++ b/include/snowplow/tracker.cpp
@@ -95,7 +95,7 @@ string Tracker::track(const Event &event) {
 
   // Add Client Session if available
   if (this->m_client_session) {
-    context.push_back(this->m_client_session->update_and_get_session_context(payload.get_event_id()));
+    context.push_back(this->m_client_session->update_and_get_session_context(payload.get_event_id(), payload.get_timestamp()));
   }
 
   // Add Desktop Context if available

--- a/test/client_session_test.cpp
+++ b/test/client_session_test.cpp
@@ -13,6 +13,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include "../include/snowplow/client_session.hpp"
 #include "../include/snowplow/storage/sqlite_storage.hpp"
+#include "../include/snowplow/detail/utils/utils.hpp"
 #include "catch.hpp"
 #include <thread>
 
@@ -34,13 +35,14 @@ TEST_CASE("client_session") {
 
     ClientSession cs(storage, 500, 500);
 
-    SelfDescribingJson session_json_1 = cs.update_and_get_session_context("event-id-1");
-    SelfDescribingJson session_json_2 = cs.update_and_get_session_context("event-id-2");
+    SelfDescribingJson session_json_1 = cs.update_and_get_session_context("event-id-1", 1653042535123);
+    SelfDescribingJson session_json_2 = cs.update_and_get_session_context("event-id-2", 1653042535345);
 
     json data_1 = session_json_1.get()[SNOWPLOW_DATA];
     json data_2 = session_json_2.get()[SNOWPLOW_DATA];
 
     REQUIRE(data_1[SNOWPLOW_SESSION_FIRST_ID].get<std::string>() == data_2[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
+    REQUIRE(data_1[SNOWPLOW_SESSION_FIRST_TIMESTAMP].get<std::string>() == data_2[SNOWPLOW_SESSION_FIRST_TIMESTAMP].get<std::string>());
     REQUIRE(data_1[SNOWPLOW_SESSION_INDEX].get<unsigned long long>() == data_2[SNOWPLOW_SESSION_INDEX].get<unsigned long long>());
     REQUIRE(data_1[SNOWPLOW_SESSION_ID].get<std::string>() == data_2[SNOWPLOW_SESSION_ID].get<std::string>());
   }
@@ -55,25 +57,29 @@ TEST_CASE("client_session") {
     cs.set_is_background(true);
     REQUIRE(true == cs.get_is_background());
 
-    SelfDescribingJson session_json = cs.update_and_get_session_context("event-id");
-    REQUIRE("iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1" == session_json.get()[SNOWPLOW_SCHEMA].get<std::string>());
+    SelfDescribingJson session_json = cs.update_and_get_session_context("event-id", 1653042535123);
+    REQUIRE("iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2" == session_json.get()[SNOWPLOW_SCHEMA].get<std::string>());
 
     json data = session_json.get()[SNOWPLOW_DATA];
 
     REQUIRE("event-id" == data[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
+    REQUIRE("2022-05-20T10:28:55.123Z" == data[SNOWPLOW_SESSION_FIRST_TIMESTAMP].get<std::string>());
     REQUIRE("SQLITE" == data[SNOWPLOW_SESSION_STORAGE].get<std::string>());
     REQUIRE(1 == data[SNOWPLOW_SESSION_INDEX].get<unsigned long long>());
+    REQUIRE(1 == data[SNOWPLOW_SESSION_EVENT_INDEX].get<unsigned long long>());
 
     string user_id = data[SNOWPLOW_SESSION_USER_ID].get<std::string>();
     string current_id = data[SNOWPLOW_SESSION_ID].get<std::string>();
 
     sleep_for(milliseconds(875));
-    session_json = cs.update_and_get_session_context("event-id");
+    session_json = cs.update_and_get_session_context("event-id-2", 1653042535345);
     data = session_json.get()[SNOWPLOW_DATA];
 
-    REQUIRE("event-id" == data[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
+    REQUIRE("event-id-2" == data[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
+    REQUIRE("2022-05-20T10:28:55.345Z" == data[SNOWPLOW_SESSION_FIRST_TIMESTAMP].get<std::string>());
     REQUIRE("SQLITE" == data[SNOWPLOW_SESSION_STORAGE].get<std::string>());
     REQUIRE(2 == data[SNOWPLOW_SESSION_INDEX].get<unsigned long long>());
+    REQUIRE(1 == data[SNOWPLOW_SESSION_EVENT_INDEX].get<unsigned long long>());
     REQUIRE(user_id == data[SNOWPLOW_SESSION_USER_ID].get<std::string>());
     REQUIRE(current_id != data[SNOWPLOW_SESSION_ID].get<std::string>());
     REQUIRE(current_id == data[SNOWPLOW_SESSION_PREVIOUS_ID].get<std::string>());
@@ -84,30 +90,34 @@ TEST_CASE("client_session") {
     storage->delete_session();
 
     ClientSession cs(storage, 10000, 10000);
-    SelfDescribingJson session_json = cs.update_and_get_session_context("event-id2");
+    SelfDescribingJson session_json = cs.update_and_get_session_context("event-id2", 1653042535123);
 
     json data = session_json.get()[SNOWPLOW_DATA];
     REQUIRE(1 == data[SNOWPLOW_SESSION_INDEX].get<unsigned long long>());
+    REQUIRE(1 == data[SNOWPLOW_SESSION_EVENT_INDEX].get<unsigned long long>());
 
     ClientSession cs1(storage, 500, 500);
 
-    SelfDescribingJson session_json1 = cs1.update_and_get_session_context("event-id2");
-    REQUIRE("iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1" == session_json1.get()[SNOWPLOW_SCHEMA].get<std::string>());
+    SelfDescribingJson session_json1 = cs1.update_and_get_session_context("event-id3", 1653042535345);
+    REQUIRE("iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2" == session_json1.get()[SNOWPLOW_SCHEMA].get<std::string>());
 
     json data1 = session_json1.get()[SNOWPLOW_DATA];
 
-    REQUIRE("event-id2" == data1[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
+    REQUIRE("event-id3" == data1[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
+    REQUIRE("2022-05-20T10:28:55.345Z" == data1[SNOWPLOW_SESSION_FIRST_TIMESTAMP].get<std::string>());
     REQUIRE("SQLITE" == data1[SNOWPLOW_SESSION_STORAGE].get<std::string>());
     REQUIRE(2 == data1[SNOWPLOW_SESSION_INDEX].get<unsigned long long>());
+    REQUIRE(1 == data1[SNOWPLOW_SESSION_EVENT_INDEX].get<unsigned long long>());
 
     string user_id1 = data1[SNOWPLOW_SESSION_USER_ID].get<std::string>();
     string current_id1 = data1[SNOWPLOW_SESSION_ID].get<std::string>();
 
     sleep_for(milliseconds(850));
-    session_json1 = cs1.update_and_get_session_context("event-id2");
+    session_json1 = cs1.update_and_get_session_context("event-id4", 1653042535678);
     data1 = session_json1.get()[SNOWPLOW_DATA];
 
-    REQUIRE("event-id2" == data1[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
+    REQUIRE("event-id4" == data1[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
+    REQUIRE("2022-05-20T10:28:55.678Z" == data1[SNOWPLOW_SESSION_FIRST_TIMESTAMP].get<std::string>());
     REQUIRE("SQLITE" == data1[SNOWPLOW_SESSION_STORAGE].get<std::string>());
     REQUIRE(3 == data1[SNOWPLOW_SESSION_INDEX].get<unsigned long long>());
     REQUIRE(user_id1 == data1[SNOWPLOW_SESSION_USER_ID].get<std::string>());
@@ -121,20 +131,21 @@ TEST_CASE("client_session") {
 
     ClientSession cs(storage, 500, 500);
 
-    SelfDescribingJson session_json = cs.update_and_get_session_context("event-id3");
-    REQUIRE("iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1" == session_json.get()[SNOWPLOW_SCHEMA].get<std::string>());
+    SelfDescribingJson session_json = cs.update_and_get_session_context("event-id3", Utils::get_unix_epoch_ms());
+    REQUIRE("iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2" == session_json.get()[SNOWPLOW_SCHEMA].get<std::string>());
 
     json data = session_json.get()[SNOWPLOW_DATA];
 
     REQUIRE("event-id3" == data[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
     REQUIRE("SQLITE" == data[SNOWPLOW_SESSION_STORAGE].get<std::string>());
     REQUIRE(1 == data[SNOWPLOW_SESSION_INDEX].get<unsigned long long>());
+    REQUIRE(1 == data[SNOWPLOW_SESSION_EVENT_INDEX].get<unsigned long long>());
 
     string user_id = data[SNOWPLOW_SESSION_USER_ID].get<std::string>();
     string current_id = data[SNOWPLOW_SESSION_ID].get<std::string>();
 
     sleep_for(milliseconds(850));
-    session_json = cs.update_and_get_session_context("event-id3");
+    session_json = cs.update_and_get_session_context("event-id3", Utils::get_unix_epoch_ms());
     data = session_json.get()[SNOWPLOW_DATA];
 
     REQUIRE("event-id3" == data[SNOWPLOW_SESSION_FIRST_ID].get<std::string>());
@@ -152,9 +163,9 @@ TEST_CASE("client_session") {
     ClientSession cs(storage, 500, 1);
     cs.set_is_background(true);
 
-    SelfDescribingJson session_json_1 = cs.update_and_get_session_context("event-id-1");
+    SelfDescribingJson session_json_1 = cs.update_and_get_session_context("event-id-1", Utils::get_unix_epoch_ms());
     sleep_for(milliseconds(5));
-    SelfDescribingJson session_json_2 = cs.update_and_get_session_context("event-id-2");
+    SelfDescribingJson session_json_2 = cs.update_and_get_session_context("event-id-2", Utils::get_unix_epoch_ms());
 
     json data_1 = session_json_1.get()[SNOWPLOW_DATA];
     json data_2 = session_json_2.get()[SNOWPLOW_DATA];
@@ -163,9 +174,9 @@ TEST_CASE("client_session") {
 
     cs.set_is_background(false);
 
-    SelfDescribingJson session_json_3 = cs.update_and_get_session_context("event-id-3");
+    SelfDescribingJson session_json_3 = cs.update_and_get_session_context("event-id-3", Utils::get_unix_epoch_ms());
     sleep_for(milliseconds(5));
-    SelfDescribingJson session_json_4 = cs.update_and_get_session_context("event-id-4");
+    SelfDescribingJson session_json_4 = cs.update_and_get_session_context("event-id-4", Utils::get_unix_epoch_ms());
 
     json data_3 = session_json_3.get()[SNOWPLOW_DATA];
     json data_4 = session_json_4.get()[SNOWPLOW_DATA];
@@ -179,15 +190,31 @@ TEST_CASE("client_session") {
 
     ClientSession cs(storage, 500, 1);
 
-    SelfDescribingJson session_json_1 = cs.update_and_get_session_context("event-id-1");
+    SelfDescribingJson session_json_1 = cs.update_and_get_session_context("event-id-1", Utils::get_unix_epoch_ms());
     cs.set_is_background(true);
     sleep_for(milliseconds(5));
     cs.set_is_background(false);
-    SelfDescribingJson session_json_2 = cs.update_and_get_session_context("event-id-2");
+    SelfDescribingJson session_json_2 = cs.update_and_get_session_context("event-id-2", Utils::get_unix_epoch_ms());
 
     json data_1 = session_json_1.get()[SNOWPLOW_DATA];
     json data_2 = session_json_2.get()[SNOWPLOW_DATA];
 
     REQUIRE(data_1[SNOWPLOW_SESSION_INDEX].get<unsigned long long>() < data_2[SNOWPLOW_SESSION_INDEX].get<unsigned long long>());
+  }
+
+  SECTION("The event index increases for subsequent tracked events") {
+    auto storage = std::make_shared<SqliteStorage>("test1.db");
+    storage->delete_session();
+
+    ClientSession cs(storage, 500, 500);
+
+    SelfDescribingJson session_json_1 = cs.update_and_get_session_context("event-id-1", Utils::get_unix_epoch_ms());
+    SelfDescribingJson session_json_2 = cs.update_and_get_session_context("event-id-2", Utils::get_unix_epoch_ms());
+
+    json data_1 = session_json_1.get()[SNOWPLOW_DATA];
+    json data_2 = session_json_2.get()[SNOWPLOW_DATA];
+
+    REQUIRE(1 == data_1[SNOWPLOW_SESSION_EVENT_INDEX].get<int>());
+    REQUIRE(2 == data_2[SNOWPLOW_SESSION_EVENT_INDEX].get<int>());
   }
 }

--- a/test/integration/integration_test.cpp
+++ b/test/integration/integration_test.cpp
@@ -91,7 +91,9 @@ TEST_CASE("integration") {
     event = good.back()["event"].get<json>();
     entities = event["contexts"].get<json>()["data"].get<list<json>>();
     auto entity2 = entities.front()["data"].get<json>();
+    REQUIRE(entity2["eventIndex"].get<int>() != entity1["eventIndex"].get<int>());
     REQUIRE(entity2["firstEventId"] == event_id);
+    REQUIRE(entity2["firstEventTimestamp"] == entity1["firstEventTimestamp"]);
     REQUIRE(entity2["userId"] == entity1["userId"]);
     REQUIRE(entity2["sessionId"] == entity1["sessionId"]);
 

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -87,6 +87,10 @@ TEST_CASE("utils") {
     REQUIRE(13 == std::to_string(Utils::get_unix_epoch_ms()).length());
   }
 
+  SECTION("get_unix_epoch_ms_as_datetime_string should return the ISO formatted datetime") {
+    REQUIRE("2022-05-20T10:28:55.123Z" == Utils::get_unix_epoch_ms_as_datetime_string(1653042535123));
+  }
+
   SECTION("get_device_context should populate OS specific information correctly") {
     string os_type = Utils::get_os_type();
     string os_version = Utils::get_os_version();


### PR DESCRIPTION
This PR addresses issue #80 and implements `client_session` schema version 1-0-2 with two new properties:

1. `firstEventTimestamp` – Timestamp of when the first event in the session was tracked. Taken from the device created timestamp of the first event in the session.
2. `eventIndex` – Index of the current event in the session. Starts at 1 as the `sessionIndex`.

The build is currently failing because of the integration tests since the schema is not yet published and Micro is not able to retrieve it.