### PR TITLE
Silence warnings during build

### DIFF
--- a/include/snowplow/client_session.cpp
+++ b/include/snowplow/client_session.cpp
@@ -25,7 +25,7 @@ using std::move;
 
 ClientSession::ClientSession(const SessionConfiguration &session_config) :
   ClientSession(
-    move(session_config.get_session_store()),
+    session_config.get_session_store(),
     session_config.get_foreground_timeout(),
     session_config.get_background_timeout()
   ) {
@@ -85,7 +85,7 @@ SelfDescribingJson ClientSession::update_and_get_session_context(const string &e
     session_context_data = this->m_session_context_data;
 
     m_event_index++;
-    event_index = m_event_index;
+    event_index = int(m_event_index);
   }
 
   if (save_to_storage) {

--- a/include/snowplow/detail/base64/base64.cpp
+++ b/include/snowplow/detail/base64/base64.cpp
@@ -27,7 +27,9 @@
 #include "base64.hpp"
 #include <iostream>
 
-static const std::string base64_chars = 
+using unsigned_char_t = unsigned char;
+
+static const std::string base64_chars =
              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
              "abcdefghijklmnopqrstuvwxyz"
              "0123456789+/";
@@ -47,8 +49,8 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
     char_array_3[i++] = *(bytes_to_encode++);
     if (i == 3) {
       char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
-      char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
-      char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+      char_array_4[1] = unsigned_char_t(((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4));
+      char_array_4[2] = unsigned_char_t(((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6));
       char_array_4[3] = char_array_3[2] & 0x3f;
 
       for (i = 0; (i <4) ; i++)
@@ -62,8 +64,8 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
       char_array_3[j] = '\0';
 
     char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
-    char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
-    char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+    char_array_4[1] = unsigned_char_t(((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4));
+    char_array_4[2] = unsigned_char_t(((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6));
     char_array_4[3] = char_array_3[2] & 0x3f;
 
     for (j = 0; (j < i + 1); j++)
@@ -77,7 +79,7 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
 }
 
 std::string base64_decode(std::string const& encoded_string) {
-  int in_len = encoded_string.size();
+  int in_len = int(encoded_string.size());
   int i = 0;
   int j = 0;
   int in_ = 0;
@@ -88,11 +90,11 @@ std::string base64_decode(std::string const& encoded_string) {
     char_array_4[i++] = encoded_string[in_]; in_++;
     if (i == 4) {
       for (i = 0; i < 4; i++)
-        char_array_4[i] = base64_chars.find(char_array_4[i]);
+        char_array_4[i] = unsigned_char_t(base64_chars.find(char_array_4[i]));
 
-      char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-      char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-      char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+      char_array_3[0] = unsigned_char_t((char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4));
+      char_array_3[1] = unsigned_char_t(((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2));
+      char_array_3[2] = unsigned_char_t(((char_array_4[2] & 0x3) << 6) + char_array_4[3]);
 
       for (i = 0; (i < 3); i++)
         ret += char_array_3[i];
@@ -105,11 +107,11 @@ std::string base64_decode(std::string const& encoded_string) {
       char_array_4[j] = 0;
 
     for (j = 0; j < 4; j++)
-      char_array_4[j] = base64_chars.find(char_array_4[j]);
+      char_array_4[j] = unsigned_char_t(base64_chars.find(char_array_4[j]));
 
-    char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-    char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-    char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+    char_array_3[0] = unsigned_char_t((char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4));
+    char_array_3[1] = unsigned_char_t(((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2));
+    char_array_3[2] = unsigned_char_t(((char_array_4[2] & 0x3) << 6) + char_array_4[3]);
 
     for (j = 0; (j < i - 1); j++) 
       ret += char_array_3[j];

--- a/include/snowplow/detail/http/request_macos.mm
+++ b/include/snowplow/detail/http/request_macos.mm
@@ -51,7 +51,7 @@ int snowplow::make_request(bool is_post, const string &url, const string &post_d
 
     dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
 
-    return [httpResponse statusCode];
+    return int([httpResponse statusCode]);
 }
 
 #endif

--- a/include/snowplow/detail/utils/utils.cpp
+++ b/include/snowplow/detail/utils/utils.cpp
@@ -177,6 +177,7 @@ string Utils::get_os_version() {
   OSVERSIONINFOEX osviex;
   ::ZeroMemory(&osviex, sizeof(OSVERSIONINFOEX));
   osviex.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
+  #pragma warning(suppress: 4996) // 'GetVersionExW': was declared deprecated
   ::GetVersionEx((LPOSVERSIONINFO)&osviex);
   return to_string(osviex.dwMajorVersion) + "." + to_string(osviex.dwMinorVersion) + "." + to_string(osviex.dwBuildNumber);
 }
@@ -185,6 +186,7 @@ string Utils::get_os_service_pack() {
   OSVERSIONINFOEX osviex;
   ::ZeroMemory(&osviex, sizeof(OSVERSIONINFOEX));
   osviex.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
+  #pragma warning(suppress: 4996) // 'GetVersionExW': was declared deprecated
   ::GetVersionEx((LPOSVERSIONINFO)&osviex);
   return to_string(osviex.wServicePackMajor) + "." + to_string(osviex.wServicePackMinor);
 }

--- a/include/snowplow/detail/utils/utils.cpp
+++ b/include/snowplow/detail/utils/utils.cpp
@@ -76,7 +76,7 @@ string Utils::get_uuid4() {
 string Utils::int_list_to_string(const list<int> &int_list, const string &delimiter) {
   stringstream s;
   int i = 0;
-  int length = int_list.size();
+  int length = int(int_list.size());
 
   for (auto const &value : int_list) {
     s << value;
@@ -94,7 +94,7 @@ string Utils::map_to_query_string(map<string, string> m) {
   int i;
   map<string, string>::iterator it;
 
-  int length = m.size();
+  int length = int(m.size());
   for (i = 0, it = m.begin(); it != m.end(); ++it, ++i) {
     s << Utils::url_encode(it->first) << "=" << Utils::url_encode(it->second);
     if (i < length - 1) {

--- a/include/snowplow/emitter/emitter.cpp
+++ b/include/snowplow/emitter/emitter.cpp
@@ -50,14 +50,14 @@ unique_ptr<HttpClient> createDefaultHttpClient(const string &curl_cookie_file) {
 
 Emitter::Emitter(NetworkConfiguration &network_config, const EmitterConfiguration &emitter_config) :
   Emitter(
-    move(emitter_config.get_event_store()),
+    emitter_config.get_event_store(),
     network_config.get_collector_hostname(),
     network_config.get_method(),
     network_config.get_protocol(),
     emitter_config.get_batch_size(),
     emitter_config.get_byte_limit_post(),
     emitter_config.get_byte_limit_get(),
-    move(network_config.move_http_client()),
+    network_config.move_http_client(),
     network_config.get_curl_cookie_file()
   ) {
   m_callback = emitter_config.get_request_callback();
@@ -223,7 +223,7 @@ void Emitter::do_send(const list<EventRow> &event_rows, list<HttpRequestResult> 
     int total_byte_size = 0;
 
     for (auto const &row : event_rows) {
-      unsigned int byte_size = Utils::serialize_payload(row.event).size() + post_stm_bytes;
+      unsigned int byte_size = unsigned(Utils::serialize_payload(row.event).size() + post_stm_bytes);
 
       if ((byte_size + post_wrapper_bytes) > this->m_byte_limit_post) {
         // A single payload has exceeded the Byte Limit

--- a/include/snowplow/http/http_client_curl.cpp
+++ b/include/snowplow/http/http_client_curl.cpp
@@ -81,7 +81,7 @@ HttpRequestResult HttpClientCurl::http_request(const RequestMethod method, Crack
   curl_easy_cleanup(curl);
   curl_slist_free_all(headers);
 
-  return HttpRequestResult(0, status_code, row_ids, oversize);
+  return HttpRequestResult(0, int(status_code), row_ids, oversize);
 }
 
 #endif

--- a/include/snowplow/http/http_client_windows.cpp
+++ b/include/snowplow/http/http_client_windows.cpp
@@ -22,8 +22,8 @@ const string HttpClientWindows::TRACKER_AGENT = string("Snowplow C++ Tracker (Wi
 
 HttpRequestResult HttpClientWindows::http_request(const RequestMethod method, CrackedUrl url, const string &query_string, const string &post_data, list<int> row_ids, bool oversize) {
 
-  HINTERNET h_internet = InternetOpen(
-      TEXT(HttpClientWindows::TRACKER_AGENT.c_str()),
+  HINTERNET h_internet = InternetOpenA(
+      HttpClientWindows::TRACKER_AGENT.c_str(),
       INTERNET_OPEN_TYPE_DIRECT,
       NULL,
       NULL,
@@ -42,9 +42,9 @@ HttpRequestResult HttpClientWindows::http_request(const RequestMethod method, Cr
     }
   }
 
-  HINTERNET h_connect = InternetConnect(
+  HINTERNET h_connect = InternetConnectA(
       h_internet,
-      TEXT(url.get_hostname().c_str()),
+      url.get_hostname().c_str(),
       use_port,
       NULL,
       NULL,
@@ -73,14 +73,14 @@ HttpRequestResult HttpClientWindows::http_request(const RequestMethod method, Cr
     final_path += "?" + query_string;
   } else {
     request_method_string = "POST";
-    post_buf = (LPVOID)TEXT(post_data.c_str());
-    post_buf_len = strlen(TEXT(post_data.c_str()));
+    post_buf = (LPVOID)(post_data.c_str());
+    post_buf_len = int(strlen(post_data.c_str()));
   }
 
-  HINTERNET h_request = HttpOpenRequest(
+  HINTERNET h_request = HttpOpenRequestA(
       h_connect,
-      TEXT(request_method_string.c_str()),
-      TEXT(final_path.c_str()),
+      request_method_string.c_str(),
+      final_path.c_str(),
       NULL,
       NULL,
       NULL,
@@ -93,8 +93,8 @@ HttpRequestResult HttpClientWindows::http_request(const RequestMethod method, Cr
     return HttpRequestResult(GetLastError(), 0, row_ids, oversize);
   }
 
-  LPCSTR hdrs = TEXT("Content-Type: application/json; charset=utf-8");
-  BOOL is_sent = HttpSendRequest(h_request, hdrs, strlen(hdrs), post_buf, post_buf_len);
+  LPCSTR hdrs = "Content-Type: application/json; charset=utf-8";
+  BOOL is_sent = HttpSendRequestA(h_request, hdrs, DWORD(strlen(hdrs)), post_buf, DWORD(post_buf_len));
 
   if (!is_sent) {
     InternetCloseHandle(h_internet);

--- a/include/snowplow/payload/payload.cpp
+++ b/include/snowplow/payload/payload.cpp
@@ -41,7 +41,7 @@ void Payload::add_payload(const Payload &p) {
 void Payload::add_json(const json &j, bool base64Encode, const string &encoded, const string &not_encoded) {
   if (base64Encode) {
     string json_str = j.dump();
-    this->add(encoded, base64_encode((const unsigned char *)json_str.c_str(), json_str.length()));
+    this->add(encoded, base64_encode((const unsigned char *)json_str.c_str(), unsigned(json_str.length())));
   } else {
     this->add(not_encoded, j.dump());
   }

--- a/include/snowplow/storage/sqlite_storage.cpp
+++ b/include/snowplow/storage/sqlite_storage.cpp
@@ -115,7 +115,7 @@ void SqliteStorage::add_event(const Payload &payload) {
 
   string payload_str = Utils::serialize_payload(payload);
 
-  rc = sqlite3_bind_text(this->m_add_stmt, 1, payload_str.c_str(), payload_str.length(), SQLITE_STATIC);
+  rc = sqlite3_bind_text(this->m_add_stmt, 1, payload_str.c_str(), int(payload_str.length()), SQLITE_STATIC);
   if (rc != SQLITE_OK) {
     cerr << "ERROR: Failed to bind payload to statement: " << rc << endl;
     return;
@@ -158,7 +158,7 @@ void SqliteStorage::set_session(const json &session_data) {
   }
 
   string session_data_str = session_data.dump();
-  rc = sqlite3_bind_text(insert_stmt, 2, session_data_str.c_str(), session_data_str.length(), SQLITE_STATIC);
+  rc = sqlite3_bind_text(insert_stmt, 2, session_data_str.c_str(), int(session_data_str.length()), SQLITE_STATIC);
   if (rc != SQLITE_OK) {
     cerr << "ERROR: Failed to bind data to statement: " << rc << endl;
     return;

--- a/test/integration/micro.cpp
+++ b/test/integration/micro.cpp
@@ -50,9 +50,9 @@ string Micro::request(const string &path) {
       NULL,
       0);
 
-  HINTERNET h_connect = InternetConnect(
+  HINTERNET h_connect = InternetConnectA(
       h_internet,
-      TEXT(SNOWPLOW_MICRO_HOSTNAME.c_str()),
+      SNOWPLOW_MICRO_HOSTNAME.c_str(),
       9090,
       NULL,
       NULL,
@@ -60,17 +60,17 @@ string Micro::request(const string &path) {
       0,
       NULL);
 
-  HINTERNET h_request = HttpOpenRequest(
+  HINTERNET h_request = HttpOpenRequestA(
       h_connect,
-      TEXT("GET"),
-      TEXT(path.c_str()),
+      "GET",
+      path.c_str(),
       NULL,
       NULL,
       NULL,
       0 | INTERNET_FLAG_RELOAD,
       0);
 
-  LPCSTR hdrs = TEXT("Content-Type: application/json; charset=utf-8");
+  LPCTSTR hdrs = TEXT("Content-Type: application/json; charset=utf-8");
   BOOL is_sent = HttpSendRequest(h_request, hdrs, strlen(hdrs), NULL, 0);
 
   string response;


### PR DESCRIPTION
The motivation of this PR is to make this project build within our projects since the currently supported method of including `snowplow-cpp` is to build it as part of the client project. Our projects has different settings which makes certain warnings enabled and turned into errors.

Another solution would be adding an install-target to the `CMakeLists.txt`. If you're interested, please check the [install-cmake-config](https://github.com/tamaskenezlego/snowplow-cpp-tracker/tree/install-cmake-config) branch on my fork. It would allow building Snowplow separately.

Changes in this PR:

- silence `std::move`-related warnings by remove unneccessary `std::move` on return values
- silence integer conversion warnings by applying explicit conversion
- silence `GetVersionEx` deprecation warnings with a local `#pragma` (Windows)
- fix illegal use of the `TEXT` macro on non-literal c-strings (Windows)

A comment about the `TEXT` macro and Windows code pages:

The `TEXT` macro should only be used on string literals. It does not convert ANSI strings to UTF-16. I fixed this by explicitly switching to the ANSI version of the Windows-API function. Note that using the ANSI versions (which happens also before this PR) is only correct if the strings are ASCII strings or are encoded with the current ANSI code page.


