### PR TITLE
Qualify usages of std::move

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -20,6 +20,7 @@ using std::cout;
 using std::endl;
 using std::string;
 using std::make_shared;
+using std::list;
 
 void usage(char *program_name) {
   cout << "Usage: " << program_name << " [COLLECTOR_URI]" << endl;

--- a/include/snowplow/client_session.cpp
+++ b/include/snowplow/client_session.cpp
@@ -21,7 +21,6 @@ using std::lock_guard;
 using std::unique_lock;
 using std::shared_ptr;
 using std::unique_ptr;
-using std::move;
 
 ClientSession::ClientSession(const SessionConfiguration &session_config) :
   ClientSession(
@@ -32,7 +31,7 @@ ClientSession::ClientSession(const SessionConfiguration &session_config) :
 }
 
 ClientSession::ClientSession(shared_ptr<SessionStore> session_store, unsigned long long foreground_timeout, unsigned long long background_timeout) {
-  this->m_session_store = move(session_store);
+  this->m_session_store = std::move(session_store);
   this->m_foreground_timeout = foreground_timeout;
   this->m_background_timeout = background_timeout;
 

--- a/include/snowplow/client_session.hpp
+++ b/include/snowplow/client_session.hpp
@@ -22,12 +22,13 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "configuration/session_configuration.hpp"
 #include "constants.hpp"
 
+namespace snowplow {
+
 using std::string;
 using std::mutex;
 using std::shared_ptr;
 using json = nlohmann::json;
 
-namespace snowplow {
 /**
  * @brief Keeps track of users sessions and can be configured to timeout after a certain amount of inactivity.
  * 

--- a/include/snowplow/configuration/emitter_configuration.cpp
+++ b/include/snowplow/configuration/emitter_configuration.cpp
@@ -16,9 +16,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../constants.hpp"
 
 using namespace snowplow;
-using std::move;
 
-EmitterConfiguration::EmitterConfiguration(shared_ptr<EventStore> event_store) : m_event_store(move(event_store)), m_db_name("") {
+EmitterConfiguration::EmitterConfiguration(shared_ptr<EventStore> event_store) : m_event_store(std::move(event_store)), m_db_name("") {
   if (!m_event_store) {
     throw std::invalid_argument("Invalid emitter event store");
   }

--- a/include/snowplow/configuration/emitter_configuration.hpp
+++ b/include/snowplow/configuration/emitter_configuration.hpp
@@ -19,12 +19,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../emitter/emit_status.hpp"
 #include "../storage/sqlite_storage.hpp"
 
+namespace snowplow {
+
 using std::shared_ptr;
 using std::string;
 using std::move;
 using std::make_shared;
-
-namespace snowplow {
 
 typedef std::function<void(list<string>, EmitStatus)> EmitterCallback;
 

--- a/include/snowplow/configuration/emitter_configuration.hpp
+++ b/include/snowplow/configuration/emitter_configuration.hpp
@@ -23,7 +23,6 @@ namespace snowplow {
 
 using std::shared_ptr;
 using std::string;
-using std::move;
 using std::make_shared;
 
 typedef std::function<void(list<string>, EmitStatus)> EmitterCallback;

--- a/include/snowplow/configuration/network_configuration.hpp
+++ b/include/snowplow/configuration/network_configuration.hpp
@@ -19,11 +19,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../http/http_enums.hpp"
 #include "../http/http_client.hpp"
 
+namespace snowplow {
+
 using std::shared_ptr;
 using std::unique_ptr;
 using std::string;
 
-namespace snowplow {
 /**
  * @brief Configuration object containing Snowplow collector settings used to initialize an emitter.
  */

--- a/include/snowplow/configuration/network_configuration.hpp
+++ b/include/snowplow/configuration/network_configuration.hpp
@@ -70,7 +70,7 @@ public:
    * 
    * @param http_client Unique pointer to a custom HTTP client to send GET and POST requests with.
    */
-  void set_http_client(unique_ptr<HttpClient> http_client) { m_http_client = move(http_client); }
+  void set_http_client(unique_ptr<HttpClient> http_client) { m_http_client = std::move(http_client); }
 
 private:
   /**
@@ -78,7 +78,7 @@ private:
    * 
    * @return unique_ptr<HttpClient> Unique pointer to the HTTP client.
    */
-  unique_ptr<HttpClient> move_http_client() { return m_http_client ? move(m_http_client) : nullptr; }
+  unique_ptr<HttpClient> move_http_client() { return m_http_client ? std::move(m_http_client) : nullptr; }
 
   string m_collector_hostname;
   string m_curl_cookie_file;

--- a/include/snowplow/configuration/session_configuration.cpp
+++ b/include/snowplow/configuration/session_configuration.cpp
@@ -15,11 +15,10 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../storage/sqlite_storage.hpp"
 
 using namespace snowplow;
-using std::move;
 using std::make_shared;
 
 SessionConfiguration::SessionConfiguration(shared_ptr<SessionStore> session_store, unsigned long long foreground_timeout, unsigned long long background_timeout) {
-  m_session_store = move(session_store);
+  m_session_store = std::move(session_store);
   m_db_name = "";
   m_foreground_timeout = foreground_timeout;
   m_background_timeout = background_timeout;

--- a/include/snowplow/configuration/session_configuration.hpp
+++ b/include/snowplow/configuration/session_configuration.hpp
@@ -24,7 +24,6 @@ namespace snowplow {
 
 using std::shared_ptr;
 using std::string;
-using std::move;
 
 /**
  * @brief Configuration object containing settings used to initialize client session tracking.
@@ -85,7 +84,7 @@ public:
    * 
    * @param session_store Defines the database to use for session storage
    */
-  void set_session_store(shared_ptr<SessionStore> session_store) { m_session_store = move(session_store); }
+  void set_session_store(shared_ptr<SessionStore> session_store) { m_session_store = std::move(session_store); }
 
 private:
   unsigned long long m_foreground_timeout;

--- a/include/snowplow/configuration/session_configuration.hpp
+++ b/include/snowplow/configuration/session_configuration.hpp
@@ -20,11 +20,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../emitter/emit_status.hpp"
 #include "../constants.hpp"
 
+namespace snowplow {
+
 using std::shared_ptr;
 using std::string;
 using std::move;
 
-namespace snowplow {
 /**
  * @brief Configuration object containing settings used to initialize client session tracking.
  * 

--- a/include/snowplow/configuration/tracker_configuration.hpp
+++ b/include/snowplow/configuration/tracker_configuration.hpp
@@ -16,10 +16,10 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include <string>
 
+namespace snowplow {
+
 using std::shared_ptr;
 using std::string;
-
-namespace snowplow {
 
 /**
  * @brief Device platform that the app is run on.

--- a/include/snowplow/constants.hpp
+++ b/include/snowplow/constants.hpp
@@ -17,10 +17,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include <string>
 #include <set>
 
+namespace snowplow {
+
 using std::string;
 using std::set;
 
-namespace snowplow {
 const string SNOWPLOW_TRACKER_VERSION_LABEL = "cpp-1.0.0";
 
 // post requests

--- a/include/snowplow/cracked_url.hpp
+++ b/include/snowplow/cracked_url.hpp
@@ -18,9 +18,10 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include <sstream>
 #include <regex>
 
+namespace snowplow {
+
 using std::string;
 
-namespace snowplow {
 /**
  * @brief Parser for collector URLs. To be used internally within tracker only.
  */

--- a/include/snowplow/detail/http/request_macos_interface.h
+++ b/include/snowplow/detail/http/request_macos_interface.h
@@ -18,9 +18,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include <string>
 
-using std::string;
-
 namespace snowplow {
+using std::string;
 int make_request(bool is_post, const string &url, const string &post_data);
 }
 

--- a/include/snowplow/detail/utils/utils.hpp
+++ b/include/snowplow/detail/utils/utils.hpp
@@ -43,11 +43,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #endif
 
+namespace snowplow {
+
 using std::list;
 using std::string;
 using json = nlohmann::json;
 
-namespace snowplow {
 /**
  * @brief Tracker internal utility functions.
  */

--- a/include/snowplow/detail/utils/utils_macos.mm
+++ b/include/snowplow/detail/utils/utils_macos.mm
@@ -17,7 +17,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 @implementation UtilsMacOS
 
-string snowplow::get_os_version_objc() {
+std::string snowplow::get_os_version_objc() {
     return ([[UtilsMacOS getOSVersion] UTF8String]);
 }
 

--- a/include/snowplow/detail/utils/utils_macos_interface.h
+++ b/include/snowplow/detail/utils/utils_macos_interface.h
@@ -16,9 +16,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include <string>
 
-using std::string;
-
 namespace snowplow {
+using std::string;
 string get_os_version_objc();
 }
 

--- a/include/snowplow/emitter/emitter.cpp
+++ b/include/snowplow/emitter/emitter.cpp
@@ -24,7 +24,6 @@ using std::async;
 using std::to_string;
 using std::transform;
 using std::equal;
-using std::move;
 using std::future;
 using std::this_thread::sleep_for;
 
@@ -91,9 +90,9 @@ Emitter::Emitter(shared_ptr<EventStore> event_store, const string &uri, Method m
   this->m_batch_size = batch_size;
   this->m_byte_limit_post = byte_limit_post;
   this->m_byte_limit_get = byte_limit_get;
-  this->m_event_store = move(event_store);
+  this->m_event_store = std::move(event_store);
   if (http_client) {
-    this->m_http_client = move(http_client);
+    this->m_http_client = std::move(http_client);
   } else {
     this->m_http_client = createDefaultHttpClient(curl_cookie_file);
   }

--- a/include/snowplow/emitter/emitter.hpp
+++ b/include/snowplow/emitter/emitter.hpp
@@ -34,6 +34,8 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "retry_delay.hpp"
 #include "../http/http_enums.hpp"
 
+namespace snowplow {
+
 using std::string;
 using std::thread;
 using std::condition_variable;
@@ -41,8 +43,6 @@ using std::mutex;
 using std::unique_ptr;
 using std::list;
 using std::shared_ptr;
-
-namespace snowplow {
 
 /**
  * @brief Emitter is responsible for sending events to a Snowplow Collector.

--- a/include/snowplow/emitter/retry_delay.hpp
+++ b/include/snowplow/emitter/retry_delay.hpp
@@ -16,9 +16,10 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include <chrono>
 
+namespace snowplow {
+
 using std::chrono::milliseconds;
 
-namespace snowplow {
 /**
  * @brief Calculates exponential retry delay for Emitter based on the number of retry attempts.
  */

--- a/include/snowplow/events/event.cpp
+++ b/include/snowplow/events/event.cpp
@@ -17,7 +17,6 @@ See the Apache License Version 2.0 for the specific language governing permissio
 using namespace snowplow;
 using std::to_string;
 using std::invalid_argument;
-using std::move;
 
 Event::Event() {
   this->m_true_timestamp = NULL;
@@ -73,5 +72,5 @@ void Event::set_context(const vector<SelfDescribingJson> &context) {
 }
 
 void Event::set_subject(shared_ptr<Subject> subject) {
-  m_subject = move(subject);
+  m_subject = std::move(subject);
 }

--- a/include/snowplow/events/event.hpp
+++ b/include/snowplow/events/event.hpp
@@ -20,11 +20,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include <string>
 #include <vector>
 
+namespace snowplow {
+
 using std::string;
 using std::vector;
 using std::shared_ptr;
 
-namespace snowplow {
 /**
  * @brief Base class for all event types that concrete event types inherit from.
  */

--- a/include/snowplow/http/http_client.hpp
+++ b/include/snowplow/http/http_client.hpp
@@ -18,10 +18,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../cracked_url.hpp"
 #include "http_request_result.hpp"
 
+namespace snowplow {
+
 using std::string;
 using std::list;
 
-namespace snowplow {
 /**
  * @brief Abstract base class for HTTP client for making requests to Snowplow Collector. It is used by Emitter.
  */

--- a/include/snowplow/http/http_client_apple.hpp
+++ b/include/snowplow/http/http_client_apple.hpp
@@ -19,10 +19,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #include <string>
 
+namespace snowplow {
+
 using std::string;
 using std::list;
 
-namespace snowplow {
 /**
  * @brief HTTP client for making requests to Snowplow Collector using Apple Core Foundation APIs.
  * 

--- a/include/snowplow/http/http_client_curl.hpp
+++ b/include/snowplow/http/http_client_curl.hpp
@@ -21,10 +21,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
+namespace snowplow {
+
 using std::string;
 using std::list;
 
-namespace snowplow {
 /**
  * @brief HTTP client that uses the Curl library for making requests to Snowplow Collector.
  * 

--- a/include/snowplow/http/http_client_windows.hpp
+++ b/include/snowplow/http/http_client_windows.hpp
@@ -24,10 +24,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
 
 #pragma comment (lib, "wininet.lib")
 
+namespace snowplow {
+
 using std::string;
 using std::list;
 
-namespace snowplow {
 /**
  * @brief HTTP client for making requests to Snowplow Collector using Windows APIs.
  * 

--- a/include/snowplow/http/http_request_result.hpp
+++ b/include/snowplow/http/http_request_result.hpp
@@ -18,10 +18,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include <list>
 #include <map>
 
+namespace snowplow {
+
 using std::list;
 using std::map;
 
-namespace snowplow {
 /**
  * @brief Response from HTTP requests to collector. To be used internally within tracker only.
  */

--- a/include/snowplow/payload/event_payload.hpp
+++ b/include/snowplow/payload/event_payload.hpp
@@ -17,9 +17,10 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "payload.hpp"
 #include <string>
 
+namespace snowplow {
+
 using std::string;
 
-namespace snowplow {
 /**
  * @brief Payload with event properties that is created for tracked events.
  * 

--- a/include/snowplow/payload/payload.hpp
+++ b/include/snowplow/payload/payload.hpp
@@ -19,11 +19,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include <map>
 #include <string>
 
+namespace snowplow {
+
 using std::map;
 using std::string;
 using json = nlohmann::json;
 
-namespace snowplow {
 /**
  * @brief Snowplow event payload with event properties.
  */

--- a/include/snowplow/payload/self_describing_json.hpp
+++ b/include/snowplow/payload/self_describing_json.hpp
@@ -18,10 +18,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../constants.hpp"
 #include "../thirdparty/json.hpp"
 
+namespace snowplow {
+
 using std::string;
 using json = nlohmann::json;
 
-namespace snowplow {
 /**
  * @brief Self-describing JSON object used for defining self-describing events or custom context entities.
  */

--- a/include/snowplow/snowplow.cpp
+++ b/include/snowplow/snowplow.cpp
@@ -34,25 +34,25 @@ shared_ptr<Tracker> Snowplow::create_tracker(const string &name_space, const str
   return create_tracker(
       TrackerConfiguration(name_space),
       network_config,
-      EmitterConfiguration(move(event_store)),
-      move(subject));
+      EmitterConfiguration(std::move(event_store)),
+      std::move(subject));
 }
 
 shared_ptr<Tracker> Snowplow::create_tracker(const string &name_space, const string &collector_url, Method method, shared_ptr<EventStore> event_store, shared_ptr<SessionStore> session_store, shared_ptr<Subject> subject) {
   NetworkConfiguration network_config(collector_url, method);
-  SessionConfiguration session_config(move(session_store));
-  EmitterConfiguration emitter_config(move(event_store));
+  SessionConfiguration session_config(std::move(session_store));
+  EmitterConfiguration emitter_config(std::move(event_store));
   return create_tracker(
       TrackerConfiguration(name_space),
       network_config,
       emitter_config,
       session_config,
-      move(subject));
+      std::move(subject));
 }
 
 shared_ptr<Tracker> Snowplow::create_tracker(const TrackerConfiguration &tracker_config, NetworkConfiguration &network_config, const EmitterConfiguration &emitter_config, shared_ptr<Subject> subject) {
   auto emitter = make_shared<Emitter>(network_config, emitter_config);
-  auto tracker = make_shared<Tracker>(tracker_config, move(emitter), move(subject));
+  auto tracker = make_shared<Tracker>(tracker_config, std::move(emitter), std::move(subject));
   register_tracker(tracker);
   return tracker;
 }
@@ -65,7 +65,7 @@ shared_ptr<Tracker> Snowplow::create_tracker(const TrackerConfiguration &tracker
   }
   auto emitter = make_shared<Emitter>(network_config, emitter_config);
   auto client_session = make_shared<ClientSession>(session_config);
-  auto tracker = make_shared<Tracker>(tracker_config, move(emitter), move(subject), move(client_session));
+  auto tracker = make_shared<Tracker>(tracker_config, std::move(emitter), std::move(subject), std::move(client_session));
   register_tracker(tracker);
   return tracker;
 }

--- a/include/snowplow/snowplow.hpp
+++ b/include/snowplow/snowplow.hpp
@@ -58,11 +58,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include <map>
 #include <mutex>
 
+namespace snowplow {
+
 using std::shared_ptr;
 using std::map;
 using std::mutex;
 
-namespace snowplow {
 /**
  * @brief Static entry point to instance a new Snowplow tracker or manage existing trackers.
  * 

--- a/include/snowplow/storage/event_store.hpp
+++ b/include/snowplow/storage/event_store.hpp
@@ -17,9 +17,10 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "event_row.hpp"
 #include <list>
 
+namespace snowplow {
+
 using std::list;
 
-namespace snowplow {
 /**
  * @brief Storage interface used by the Emitter to store and access events.
  *

--- a/include/snowplow/storage/session_store.hpp
+++ b/include/snowplow/storage/session_store.hpp
@@ -17,11 +17,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../thirdparty/json.hpp"
 #include <list>
 
+namespace snowplow {
+
 using std::list;
 using std::unique_ptr;
 using json = nlohmann::json;
 
-namespace snowplow {
 /**
  * @brief Storage interface used by the ClientSession to store and access sessions.
  *

--- a/include/snowplow/storage/sqlite_storage.hpp
+++ b/include/snowplow/storage/sqlite_storage.hpp
@@ -22,12 +22,13 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "../thirdparty/json.hpp"
 #include "../thirdparty/sqlite3.hpp"
 
+namespace snowplow {
+
 using std::mutex;
 using std::string;
 using std::list;
 using json = nlohmann::json;
 
-namespace snowplow {
 /**
  * @brief Tracker SQLite storage for events and session information.
  *

--- a/include/snowplow/subject.hpp
+++ b/include/snowplow/subject.hpp
@@ -19,10 +19,11 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include <map>
 #include <string>
 
+namespace snowplow {
+
 using std::map;
 using std::string;
 
-namespace snowplow {
 /**
  * @brief Defines additional information about your application's environment, current user and so on, to be sent to with each tracked event.
  */

--- a/include/snowplow/tracker.cpp
+++ b/include/snowplow/tracker.cpp
@@ -20,9 +20,9 @@ using std::to_string;
 
 Tracker::Tracker(const TrackerConfiguration &tracker_config, shared_ptr<Emitter> emitter, shared_ptr<Subject> subject, shared_ptr<ClientSession> client_session) :
   Tracker(
-    move(emitter),
-    move(subject),
-    move(client_session),
+    std::move(emitter),
+    std::move(subject),
+    std::move(client_session),
     tracker_config.get_platform(),
     tracker_config.get_app_id(),
     tracker_config.get_namespace(),
@@ -33,9 +33,9 @@ Tracker::Tracker(const TrackerConfiguration &tracker_config, shared_ptr<Emitter>
 
 Tracker::Tracker(shared_ptr<Emitter> emitter, shared_ptr<Subject> subject, shared_ptr<ClientSession> client_session, const string &platform, const string &app_id,
                  const string &name_space, bool use_base64, bool desktop_context) {
-  this->m_emitter = move(emitter);
-  this->m_client_session = move(client_session);
-  this->m_subject = move(subject);
+  this->m_emitter = std::move(emitter);
+  this->m_client_session = std::move(client_session);
+  this->m_subject = std::move(subject);
   this->m_platform = platform;
   this->m_app_id = app_id;
   this->m_namespace = name_space;
@@ -67,7 +67,7 @@ void Tracker::flush() {
 // --- Setters
 
 void Tracker::set_subject(shared_ptr<Subject> subject) {
-  this->m_subject = move(subject);
+  this->m_subject = std::move(subject);
 }
 
 // --- Event Tracking

--- a/include/snowplow/tracker.hpp
+++ b/include/snowplow/tracker.hpp
@@ -22,11 +22,12 @@ See the Apache License Version 2.0 for the specific language governing permissio
 #include "events/event.hpp"
 #include "configuration/tracker_configuration.hpp"
 
+namespace snowplow {
+
 using std::string;
 using std::map;
 using std::shared_ptr;
 
-namespace snowplow {
 /**
  * @brief Instance of the Snowplow tracker that provides an interface to track Snowplow events.
  * 

--- a/performance/main.cpp
+++ b/performance/main.cpp
@@ -20,6 +20,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 using snowplow::SelfDescribingJson;
 using snowplow::SNOWPLOW_TRACKER_VERSION_LABEL;
 using snowplow::Utils;
+using nlohmann::json;
 using std::cout;
 using std::endl;
 using std::ofstream;

--- a/performance/mock_client_session.hpp
+++ b/performance/mock_client_session.hpp
@@ -19,6 +19,7 @@ See the Apache License Version 2.0 for the specific language governing permissio
 using snowplow::ClientSession;
 using snowplow::SelfDescribingJson;
 using snowplow::SessionStore;
+using nlohmann::json;
 using std::string;
 using std::shared_ptr;
 using std::move;

--- a/performance/run.cpp
+++ b/performance/run.cpp
@@ -32,6 +32,7 @@ using std::vector;
 using std::chrono::duration;
 using std::chrono::high_resolution_clock;
 using std::make_shared;
+using std::thread;
 
 void clear_storage(shared_ptr<SqliteStorage> &db_name);
 


### PR DESCRIPTION
Commit-by-commit review recommended due to the bulk changes.

The first commit "Move using declarations into snowplow namespace" moves the `using` declarations in the headers into the `snowplow` namespace. This is not essential but it's better not to pollute the global namespace since it has an effect on the user's C++ files which include the Snowplow headers.

The 2nd/3rd commit was motivated by a new warning introduced in the latest Xcode (14.3) (`-Wunqualified-std-cast-call`) which doesn't allow using an unqualified `move` even after declaring `using std::move`. The commits remove `using::move` and qualify all usages of `move`.
