### PR TITLE
Check whether the collector URI is empty in network configuration (close #83)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,8 @@ if(SNOWPLOW_BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/test/snowplow_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/integration/integration_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/integration/micro.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/configuration/network_configuration_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/configuration/emitter_configuration_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/test/utils_test.cpp)
 
     if (NOT WIN32)

--- a/include/snowplow/configuration/network_configuration.cpp
+++ b/include/snowplow/configuration/network_configuration.cpp
@@ -19,6 +19,10 @@ using namespace snowplow;
 using std::transform;
 
 NetworkConfiguration::NetworkConfiguration(const string &collector_url, Method method, const string &curl_cookie_file) {
+  if (collector_url.empty()) {
+    throw std::invalid_argument("Empty collector URL");
+  }
+
   m_method = method;
   m_curl_cookie_file = curl_cookie_file;
 

--- a/test/configuration/emitter_configuration_test.cpp
+++ b/test/configuration/emitter_configuration_test.cpp
@@ -11,8 +11,8 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "../../src/configuration/emitter_configuration.hpp"
-#include "../../src/storage/sqlite_storage.hpp"
+#include "../../include/snowplow/configuration/emitter_configuration.hpp"
+#include "../../include/snowplow/storage/sqlite_storage.hpp"
 #include "../catch.hpp"
 
 using namespace snowplow;

--- a/test/configuration/network_configuration_test.cpp
+++ b/test/configuration/network_configuration_test.cpp
@@ -11,12 +11,21 @@ software distributed under the Apache License Version 2.0 is distributed on an
 See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 */
 
-#include "../../src/configuration/network_configuration.hpp"
+#include "../../include/snowplow/configuration/network_configuration.hpp"
 #include "../catch.hpp"
 
 using namespace snowplow;
 
 TEST_CASE("network configuration") {
+  SECTION("throws an error for empty collector URL") {
+    bool error = false;
+
+    try { NetworkConfiguration(""); }
+    catch (std::invalid_argument) { error = true; }
+
+    REQUIRE(error);
+  }
+
   SECTION("parses URL with http://") {
     NetworkConfiguration config("http://com.acme.collector", POST);
 


### PR DESCRIPTION
Issue #83 

Checks that the collector URL is not empty in the `NetworkConfiguration`. In case it is, a `invalid_argument` error is thrown.

This was already the case in the `Emitter` but not in `NetworkConfiguration`.

Also includes a couple of tests in the build that were missing for some reason.