### PR TITLE
Fix SQLite storage test for SQLite >= 3.39.0

### DIFF
--- a/test/storage/sqlite_storage_test.cpp
+++ b/test/storage/sqlite_storage_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE("SQLite storage") {
   SECTION("database should throw exceptions for unmanageable errors") {
     bool runtime_error_bad_db_name = false;
     try {
-      SqliteStorage("~/");
+      SqliteStorage(".");
     } catch (runtime_error) {
       runtime_error_bad_db_name = true;
     }


### PR DESCRIPTION
This test constructs an `SqliteStorage` object with a bogus database name, and expects to see a failure. The internal call to `sqlite3_open` succeeds with `"~/"` when linking against versions of SQLite from 3.39.0 onwards, however (and creates a file with the name `"~"` in the working directory). In these newer versions, trailing slashes are stripped from the input, likely as a byproduct of the following change (from the [changelog](https://sqlite.org/changes.html)):

>The unix os interface resolves all symbolic links in database filenames
>to create a canonical name for the database before the file is opened.

Using `"."` produces the expected failure.