### PR TITLE
Set the intended default session timeout

### DIFF
--- a/include/snowplow/constants.hpp
+++ b/include/snowplow/constants.hpp
@@ -104,7 +104,7 @@ const string SNOWPLOW_SESSION_EVENT_INDEX = "eventIndex";
 const string SNOWPLOW_SESSION_STORAGE = "storageMechanism";
 const string SNOWPLOW_SESSION_FIRST_ID = "firstEventId";
 const string SNOWPLOW_SESSION_FIRST_TIMESTAMP = "firstEventTimestamp";
-const unsigned long long SNOWPLOW_SESSION_DEFAULT_TIMEOUT = 30 * 1000 * 1000; // 30 minutes
+const unsigned long long SNOWPLOW_SESSION_DEFAULT_TIMEOUT = 30 * 60 * 1000; // 30 minutes
 
 // emitter defaults
 const int SNOWPLOW_EMITTER_DEFAULT_BATCH_SIZE = 250;


### PR DESCRIPTION
The session timeout was accidentally set to 500 min rather than 30 min